### PR TITLE
Add Honeycomb SSE to MCP config

### DIFF
--- a/MCPServerManager/MCPServerManager/Models/ServerConfig.swift
+++ b/MCPServerManager/MCPServerManager/Models/ServerConfig.swift
@@ -123,6 +123,11 @@ struct ServerConfig: Codable, Equatable {
             return true
         }
 
+        // Check for SSE-type servers (Server-Sent Events)
+        if type == "sse", let urlString = url, !urlString.trimmingCharacters(in: .whitespaces).isEmpty {
+            return true
+        }
+
         // Check for standard command-based servers
         let hasCommand = command?.trimmingCharacters(in: .whitespaces).isEmpty == false
         let hasTransport = transport != nil
@@ -134,6 +139,12 @@ struct ServerConfig: Codable, Equatable {
     // MARK: - Summary
 
     var summary: String {
+        // Handle URL-based servers (HTTP, SSE)
+        if let serverType = type, (serverType == "http" || serverType == "sse"), let urlString = url {
+            let urlHost = formatURLHost(urlString)
+            return "\(serverType.uppercased()) → \(urlHost)"
+        }
+
         if let cmd = command, !cmd.trimmingCharacters(in: .whitespaces).isEmpty {
             return cmd.trimmingCharacters(in: .whitespaces)
         }

--- a/sample-config-for-review.json
+++ b/sample-config-for-review.json
@@ -79,6 +79,10 @@
     "axios": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-axios"]
+    },
+    "honeycomb": {
+      "type": "sse",
+      "url": "https://mcp.honeycomb.io/sse"
     }
   },
   "globalShortcut": "CommandOrControl+Shift+;",


### PR DESCRIPTION
- Add SSE (Server-Sent Events) type validation to ServerConfig
- Update summary display to show SSE servers with proper formatting
- Add Honeycomb MCP server to sample configuration as example
- SSE servers validated similarly to HTTP servers (require type + url)