### PR TITLE
Add theme override options to settings

### DIFF
--- a/MCPServerManager/MCPServerManager/Models/Settings.swift
+++ b/MCPServerManager/MCPServerManager/Models/Settings.swift
@@ -6,6 +6,7 @@ struct AppSettings: Codable, Equatable {
     var activeConfigIndex: Int
     var windowOpacity: Double
     var textVisibilityBoost: Double
+    var overrideTheme: String? // nil = auto-detect, otherwise use the theme name
 
     static let `default` = AppSettings(
         confirmDelete: true,
@@ -15,19 +16,22 @@ struct AppSettings: Codable, Equatable {
         ],
         activeConfigIndex: 0,
         windowOpacity: 1.0,
-        textVisibilityBoost: 0.5
+        textVisibilityBoost: 0.5,
+        overrideTheme: nil
     )
 
     init(confirmDelete: Bool = true,
          configPaths: [String] = ["~/.claude.json", "~/.settings.json"],
          activeConfigIndex: Int = 0,
          windowOpacity: Double = 1.0,
-         textVisibilityBoost: Double = 0.5) {
+         textVisibilityBoost: Double = 0.5,
+         overrideTheme: String? = nil) {
         self.confirmDelete = confirmDelete
         self.configPaths = configPaths
         self.activeConfigIndex = max(0, min(activeConfigIndex, 1)) // Ensure 0 or 1
         self.windowOpacity = max(0.3, min(windowOpacity, 1.0)) // Clamp between 0.3 and 1.0
         self.textVisibilityBoost = max(0.0, min(textVisibilityBoost, 1.0)) // Clamp between 0.0 and 1.0
+        self.overrideTheme = overrideTheme
     }
 
     var activeConfigPath: String {

--- a/MCPServerManager/MCPServerManager/Models/Theme.swift
+++ b/MCPServerManager/MCPServerManager/Models/Theme.swift
@@ -3,9 +3,21 @@ import SwiftUI
 // MARK: - Theme Type
 
 enum AppTheme: String, CaseIterable {
+    case auto = "Auto (Detect from Config)"
     case claudeCode = "Claude Code"
     case geminiCLI = "Gemini CLI"
-    case `default` = "Default"
+    case `default` = "Default (Cyberpunk)"
+    case nord = "Nord"
+    case dracula = "Dracula"
+    case solarizedDark = "Solarized Dark"
+    case solarizedLight = "Solarized Light"
+    case monokai = "Monokai Pro"
+    case oneDark = "One Dark"
+    case githubDark = "GitHub Dark"
+    case tokyoNight = "Tokyo Night"
+    case catppuccin = "Catppuccin Mocha"
+    case gruvbox = "Gruvbox Dark"
+    case palenight = "Material Palenight"
 
     // Detect theme from config path
     static func detect(from configPath: String) -> AppTheme {
@@ -192,15 +204,468 @@ struct ThemeColors {
         )
     )
 
+    static let nord = ThemeColors(
+        // Nord - Arctic, north-bluish color palette
+        mainBackground: Color(hex: "#2E3440"),
+        sidebarBackground: Color(hex: "#3B4252"),
+        panelBackground: Color(hex: "#2E3440"),
+        glassBackground: Color(hex: "#4C566A").opacity(0.1),
+        glassBorder: Color(hex: "#4C566A").opacity(0.3),
+
+        // Text - Nord Snow Storm
+        primaryText: Color(hex: "#ECEFF4"),
+        secondaryText: Color(hex: "#D8DEE9"),
+        mutedText: Color(hex: "#4C566A"),
+        textOnAccent: Color(hex: "#2E3440"),
+
+        // Accents - Nord Frost
+        primaryAccent: Color(hex: "#88C0D0"),
+        secondaryAccent: Color(hex: "#81A1C1"),
+        successColor: Color(hex: "#A3BE8C"),
+        errorColor: Color(hex: "#BF616A"),
+        warningColor: Color(hex: "#EBCB8B"),
+
+        // UI
+        borderColor: Color(hex: "#4C566A"),
+        selectionColor: Color(hex: "#88C0D0").opacity(0.3),
+        lineHighlight: Color(hex: "#3B4252"),
+
+        // Gradients
+        backgroundGradient: LinearGradient(
+            colors: [Color(hex: "#2E3440"), Color(hex: "#3B4252"), Color(hex: "#434C5E")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        ),
+        accentGradient: LinearGradient(
+            colors: [Color(hex: "#88C0D0"), Color(hex: "#81A1C1"), Color(hex: "#5E81AC")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    )
+
+    static let dracula = ThemeColors(
+        // Dracula - Dark theme with purple accents
+        mainBackground: Color(hex: "#282A36"),
+        sidebarBackground: Color(hex: "#21222C"),
+        panelBackground: Color(hex: "#282A36"),
+        glassBackground: Color(hex: "#44475A").opacity(0.2),
+        glassBorder: Color(hex: "#6272A4").opacity(0.3),
+
+        // Text
+        primaryText: Color(hex: "#F8F8F2"),
+        secondaryText: Color(hex: "#F8F8F2").opacity(0.8),
+        mutedText: Color(hex: "#6272A4"),
+        textOnAccent: Color(hex: "#282A36"),
+
+        // Accents
+        primaryAccent: Color(hex: "#BD93F9"),
+        secondaryAccent: Color(hex: "#FF79C6"),
+        successColor: Color(hex: "#50FA7B"),
+        errorColor: Color(hex: "#FF5555"),
+        warningColor: Color(hex: "#F1FA8C"),
+
+        // UI
+        borderColor: Color(hex: "#44475A"),
+        selectionColor: Color(hex: "#BD93F9").opacity(0.3),
+        lineHighlight: Color(hex: "#44475A"),
+
+        // Gradients
+        backgroundGradient: LinearGradient(
+            colors: [Color(hex: "#282A36"), Color(hex: "#21222C"), Color(hex: "#191A21")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        ),
+        accentGradient: LinearGradient(
+            colors: [Color(hex: "#BD93F9"), Color(hex: "#FF79C6"), Color(hex: "#8BE9FD")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    )
+
+    static let solarizedDark = ThemeColors(
+        // Solarized Dark - Precision colors for machines and people
+        mainBackground: Color(hex: "#002B36"),
+        sidebarBackground: Color(hex: "#073642"),
+        panelBackground: Color(hex: "#002B36"),
+        glassBackground: Color(hex: "#073642").opacity(0.5),
+        glassBorder: Color(hex: "#586E75").opacity(0.3),
+
+        // Text
+        primaryText: Color(hex: "#FDF6E3"),
+        secondaryText: Color(hex: "#EEE8D5"),
+        mutedText: Color(hex: "#586E75"),
+        textOnAccent: Color(hex: "#002B36"),
+
+        // Accents
+        primaryAccent: Color(hex: "#268BD2"),
+        secondaryAccent: Color(hex: "#2AA198"),
+        successColor: Color(hex: "#859900"),
+        errorColor: Color(hex: "#DC322F"),
+        warningColor: Color(hex: "#B58900"),
+
+        // UI
+        borderColor: Color(hex: "#073642"),
+        selectionColor: Color(hex: "#268BD2").opacity(0.3),
+        lineHighlight: Color(hex: "#073642"),
+
+        // Gradients
+        backgroundGradient: LinearGradient(
+            colors: [Color(hex: "#002B36"), Color(hex: "#073642"), Color(hex: "#002B36")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        ),
+        accentGradient: LinearGradient(
+            colors: [Color(hex: "#268BD2"), Color(hex: "#2AA198"), Color(hex: "#6C71C4")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    )
+
+    static let solarizedLight = ThemeColors(
+        // Solarized Light - Light theme variant
+        mainBackground: Color(hex: "#FDF6E3"),
+        sidebarBackground: Color(hex: "#EEE8D5"),
+        panelBackground: Color(hex: "#FDF6E3"),
+        glassBackground: Color(hex: "#EEE8D5").opacity(0.5),
+        glassBorder: Color(hex: "#93A1A1").opacity(0.3),
+
+        // Text
+        primaryText: Color(hex: "#002B36"),
+        secondaryText: Color(hex: "#073642"),
+        mutedText: Color(hex: "#93A1A1"),
+        textOnAccent: Color(hex: "#FDF6E3"),
+
+        // Accents
+        primaryAccent: Color(hex: "#268BD2"),
+        secondaryAccent: Color(hex: "#2AA198"),
+        successColor: Color(hex: "#859900"),
+        errorColor: Color(hex: "#DC322F"),
+        warningColor: Color(hex: "#B58900"),
+
+        // UI
+        borderColor: Color(hex: "#EEE8D5"),
+        selectionColor: Color(hex: "#268BD2").opacity(0.2),
+        lineHighlight: Color(hex: "#EEE8D5"),
+
+        // Gradients
+        backgroundGradient: LinearGradient(
+            colors: [Color(hex: "#FDF6E3"), Color(hex: "#EEE8D5"), Color(hex: "#FDF6E3")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        ),
+        accentGradient: LinearGradient(
+            colors: [Color(hex: "#268BD2"), Color(hex: "#2AA198"), Color(hex: "#6C71C4")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    )
+
+    static let monokai = ThemeColors(
+        // Monokai Pro - Warm dark theme
+        mainBackground: Color(hex: "#2D2A2E"),
+        sidebarBackground: Color(hex: "#221F22"),
+        panelBackground: Color(hex: "#2D2A2E"),
+        glassBackground: Color(hex: "#403E41").opacity(0.3),
+        glassBorder: Color(hex: "#5B595C").opacity(0.3),
+
+        // Text
+        primaryText: Color(hex: "#FCFCFA"),
+        secondaryText: Color(hex: "#FCFCFA").opacity(0.8),
+        mutedText: Color(hex: "#727072"),
+        textOnAccent: Color(hex: "#2D2A2E"),
+
+        // Accents
+        primaryAccent: Color(hex: "#FFD866"),
+        secondaryAccent: Color(hex: "#FF6188"),
+        successColor: Color(hex: "#A9DC76"),
+        errorColor: Color(hex: "#FF6188"),
+        warningColor: Color(hex: "#FC9867"),
+
+        // UI
+        borderColor: Color(hex: "#403E41"),
+        selectionColor: Color(hex: "#FFD866").opacity(0.3),
+        lineHighlight: Color(hex: "#403E41"),
+
+        // Gradients
+        backgroundGradient: LinearGradient(
+            colors: [Color(hex: "#2D2A2E"), Color(hex: "#221F22"), Color(hex: "#19181A")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        ),
+        accentGradient: LinearGradient(
+            colors: [Color(hex: "#FFD866"), Color(hex: "#FC9867"), Color(hex: "#FF6188")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    )
+
+    static let oneDark = ThemeColors(
+        // One Dark - Atom's iconic dark theme
+        mainBackground: Color(hex: "#282C34"),
+        sidebarBackground: Color(hex: "#21252B"),
+        panelBackground: Color(hex: "#282C34"),
+        glassBackground: Color(hex: "#3E4451").opacity(0.3),
+        glassBorder: Color(hex: "#3E4451").opacity(0.5),
+
+        // Text
+        primaryText: Color(hex: "#ABB2BF"),
+        secondaryText: Color(hex: "#ABB2BF").opacity(0.8),
+        mutedText: Color(hex: "#5C6370"),
+        textOnAccent: Color(hex: "#282C34"),
+
+        // Accents
+        primaryAccent: Color(hex: "#61AFEF"),
+        secondaryAccent: Color(hex: "#C678DD"),
+        successColor: Color(hex: "#98C379"),
+        errorColor: Color(hex: "#E06C75"),
+        warningColor: Color(hex: "#E5C07B"),
+
+        // UI
+        borderColor: Color(hex: "#3E4451"),
+        selectionColor: Color(hex: "#61AFEF").opacity(0.3),
+        lineHighlight: Color(hex: "#2C313A"),
+
+        // Gradients
+        backgroundGradient: LinearGradient(
+            colors: [Color(hex: "#282C34"), Color(hex: "#21252B"), Color(hex: "#181A1F")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        ),
+        accentGradient: LinearGradient(
+            colors: [Color(hex: "#61AFEF"), Color(hex: "#C678DD"), Color(hex: "#56B6C2")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    )
+
+    static let githubDark = ThemeColors(
+        // GitHub Dark - GitHub's dark theme
+        mainBackground: Color(hex: "#0D1117"),
+        sidebarBackground: Color(hex: "#161B22"),
+        panelBackground: Color(hex: "#0D1117"),
+        glassBackground: Color(hex: "#21262D").opacity(0.3),
+        glassBorder: Color(hex: "#30363D").opacity(0.5),
+
+        // Text
+        primaryText: Color(hex: "#C9D1D9"),
+        secondaryText: Color(hex: "#8B949E"),
+        mutedText: Color(hex: "#484F58"),
+        textOnAccent: Color(hex: "#FFFFFF"),
+
+        // Accents
+        primaryAccent: Color(hex: "#58A6FF"),
+        secondaryAccent: Color(hex: "#1F6FEB"),
+        successColor: Color(hex: "#3FB950"),
+        errorColor: Color(hex: "#F85149"),
+        warningColor: Color(hex: "#D29922"),
+
+        // UI
+        borderColor: Color(hex: "#30363D"),
+        selectionColor: Color(hex: "#58A6FF").opacity(0.3),
+        lineHighlight: Color(hex: "#161B22"),
+
+        // Gradients
+        backgroundGradient: LinearGradient(
+            colors: [Color(hex: "#0D1117"), Color(hex: "#161B22"), Color(hex: "#010409")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        ),
+        accentGradient: LinearGradient(
+            colors: [Color(hex: "#58A6FF"), Color(hex: "#1F6FEB"), Color(hex: "#388BFD")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    )
+
+    static let tokyoNight = ThemeColors(
+        // Tokyo Night - A clean, dark theme with neon highlights
+        mainBackground: Color(hex: "#1A1B26"),
+        sidebarBackground: Color(hex: "#16161E"),
+        panelBackground: Color(hex: "#1A1B26"),
+        glassBackground: Color(hex: "#24283B").opacity(0.3),
+        glassBorder: Color(hex: "#414868").opacity(0.3),
+
+        // Text
+        primaryText: Color(hex: "#C0CAF5"),
+        secondaryText: Color(hex: "#A9B1D6"),
+        mutedText: Color(hex: "#565F89"),
+        textOnAccent: Color(hex: "#1A1B26"),
+
+        // Accents
+        primaryAccent: Color(hex: "#7AA2F7"),
+        secondaryAccent: Color(hex: "#BB9AF7"),
+        successColor: Color(hex: "#9ECE6A"),
+        errorColor: Color(hex: "#F7768E"),
+        warningColor: Color(hex: "#E0AF68"),
+
+        // UI
+        borderColor: Color(hex: "#414868"),
+        selectionColor: Color(hex: "#7AA2F7").opacity(0.3),
+        lineHighlight: Color(hex: "#24283B"),
+
+        // Gradients
+        backgroundGradient: LinearGradient(
+            colors: [Color(hex: "#1A1B26"), Color(hex: "#16161E"), Color(hex: "#0F0F14")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        ),
+        accentGradient: LinearGradient(
+            colors: [Color(hex: "#7AA2F7"), Color(hex: "#BB9AF7"), Color(hex: "#2AC3DE")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    )
+
+    static let catppuccin = ThemeColors(
+        // Catppuccin Mocha - Warm, pastel dark theme
+        mainBackground: Color(hex: "#1E1E2E"),
+        sidebarBackground: Color(hex: "#181825"),
+        panelBackground: Color(hex: "#1E1E2E"),
+        glassBackground: Color(hex: "#313244").opacity(0.3),
+        glassBorder: Color(hex: "#45475A").opacity(0.3),
+
+        // Text
+        primaryText: Color(hex: "#CDD6F4"),
+        secondaryText: Color(hex: "#BAC2DE"),
+        mutedText: Color(hex: "#6C7086"),
+        textOnAccent: Color(hex: "#1E1E2E"),
+
+        // Accents
+        primaryAccent: Color(hex: "#89B4FA"),
+        secondaryAccent: Color(hex: "#CBA6F7"),
+        successColor: Color(hex: "#A6E3A1"),
+        errorColor: Color(hex: "#F38BA8"),
+        warningColor: Color(hex: "#F9E2AF"),
+
+        // UI
+        borderColor: Color(hex: "#45475A"),
+        selectionColor: Color(hex: "#89B4FA").opacity(0.3),
+        lineHighlight: Color(hex: "#313244"),
+
+        // Gradients
+        backgroundGradient: LinearGradient(
+            colors: [Color(hex: "#1E1E2E"), Color(hex: "#181825"), Color(hex: "#11111B")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        ),
+        accentGradient: LinearGradient(
+            colors: [Color(hex: "#89B4FA"), Color(hex: "#CBA6F7"), Color(hex: "#F5C2E7")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    )
+
+    static let gruvbox = ThemeColors(
+        // Gruvbox Dark - Retro groove color scheme
+        mainBackground: Color(hex: "#282828"),
+        sidebarBackground: Color(hex: "#1D2021"),
+        panelBackground: Color(hex: "#282828"),
+        glassBackground: Color(hex: "#3C3836").opacity(0.3),
+        glassBorder: Color(hex: "#504945").opacity(0.3),
+
+        // Text
+        primaryText: Color(hex: "#EBDBB2"),
+        secondaryText: Color(hex: "#D5C4A1"),
+        mutedText: Color(hex: "#928374"),
+        textOnAccent: Color(hex: "#282828"),
+
+        // Accents
+        primaryAccent: Color(hex: "#83A598"),
+        secondaryAccent: Color(hex: "#D3869B"),
+        successColor: Color(hex: "#B8BB26"),
+        errorColor: Color(hex: "#FB4934"),
+        warningColor: Color(hex: "#FABD2F"),
+
+        // UI
+        borderColor: Color(hex: "#504945"),
+        selectionColor: Color(hex: "#83A598").opacity(0.3),
+        lineHighlight: Color(hex: "#3C3836"),
+
+        // Gradients
+        backgroundGradient: LinearGradient(
+            colors: [Color(hex: "#282828"), Color(hex: "#1D2021"), Color(hex: "#0E1013")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        ),
+        accentGradient: LinearGradient(
+            colors: [Color(hex: "#83A598"), Color(hex: "#D3869B"), Color(hex: "#8EC07C")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    )
+
+    static let palenight = ThemeColors(
+        // Material Palenight - Deep ocean syntax theme
+        mainBackground: Color(hex: "#292D3E"),
+        sidebarBackground: Color(hex: "#1F2233"),
+        panelBackground: Color(hex: "#292D3E"),
+        glassBackground: Color(hex: "#3B3F51").opacity(0.3),
+        glassBorder: Color(hex: "#4E5579").opacity(0.3),
+
+        // Text
+        primaryText: Color(hex: "#BABFC7"),
+        secondaryText: Color(hex: "#959DCB"),
+        mutedText: Color(hex: "#676E95"),
+        textOnAccent: Color(hex: "#292D3E"),
+
+        // Accents
+        primaryAccent: Color(hex: "#82AAFF"),
+        secondaryAccent: Color(hex: "#C792EA"),
+        successColor: Color(hex: "#C3E88D"),
+        errorColor: Color(hex: "#F07178"),
+        warningColor: Color(hex: "#FFCB6B"),
+
+        // UI
+        borderColor: Color(hex: "#4E5579"),
+        selectionColor: Color(hex: "#82AAFF").opacity(0.3),
+        lineHighlight: Color(hex: "#3B3F51"),
+
+        // Gradients
+        backgroundGradient: LinearGradient(
+            colors: [Color(hex: "#292D3E"), Color(hex: "#1F2233"), Color(hex: "#15182A")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        ),
+        accentGradient: LinearGradient(
+            colors: [Color(hex: "#82AAFF"), Color(hex: "#C792EA"), Color(hex: "#89DDFF")],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    )
+
     // Get theme colors for a specific theme type
     static func forTheme(_ theme: AppTheme) -> ThemeColors {
         switch theme {
+        case .auto:
+            return .default // Will be overridden by detection logic
         case .claudeCode:
             return .claudeCode
         case .geminiCLI:
             return .geminiCLI
         case .default:
             return .default
+        case .nord:
+            return .nord
+        case .dracula:
+            return .dracula
+        case .solarizedDark:
+            return .solarizedDark
+        case .solarizedLight:
+            return .solarizedLight
+        case .monokai:
+            return .monokai
+        case .oneDark:
+            return .oneDark
+        case .githubDark:
+            return .githubDark
+        case .tokyoNight:
+            return .tokyoNight
+        case .catppuccin:
+            return .catppuccin
+        case .gruvbox:
+            return .gruvbox
+        case .palenight:
+            return .palenight
         }
     }
 

--- a/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
+++ b/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
@@ -21,7 +21,14 @@ class ServerViewModel: ObservableObject {
     // MARK: - Theme Detection
 
     var currentTheme: AppTheme {
-        AppTheme.detect(from: settings.activeConfigPath)
+        // If override theme is set, use it (unless it's "auto")
+        if let overrideThemeStr = settings.overrideTheme,
+           let overrideTheme = AppTheme(rawValue: overrideThemeStr),
+           overrideTheme != .auto {
+            return overrideTheme
+        }
+        // Otherwise, auto-detect from config path
+        return AppTheme.detect(from: settings.activeConfigPath)
     }
 
     var themeColors: ThemeColors {

--- a/MCPServerManager/MCPServerManager/Views/Modals/SettingsModal.swift
+++ b/MCPServerManager/MCPServerManager/Views/Modals/SettingsModal.swift
@@ -12,6 +12,7 @@ struct SettingsModal: View {
     @State private var fetchServerLogos: Bool = true
     @State private var windowOpacity: Double = 1.0
     @State private var textVisibilityBoost: Double = 0.5
+    @State private var selectedTheme: AppTheme = .auto
     @State private var testingConnection: Bool = false
     @State private var testResult: String = ""
     @State private var showBookmarkAlert: Bool = false
@@ -113,6 +114,30 @@ struct SettingsModal: View {
                             }
                             .buttonStyle(.plain)
                         }
+                    }
+
+                    Divider()
+
+                    // Theme Selector
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Theme")
+                            .font(DesignTokens.Typography.label)
+
+                        Picker("", selection: $selectedTheme) {
+                            ForEach(AppTheme.allCases, id: \.self) { theme in
+                                Text(theme.rawValue).tag(theme)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .onChange(of: selectedTheme) { newTheme in
+                            // Update in real-time
+                            viewModel.settings.overrideTheme = newTheme == .auto ? nil : newTheme.rawValue
+                            viewModel.saveSettings()
+                        }
+
+                        Text("Select a theme to override auto-detection. 'Auto' will detect theme based on active config (Claude Code or Gemini CLI).")
+                            .font(DesignTokens.Typography.bodySmall)
+                            .foregroundColor(.secondary)
                     }
 
                     Divider()
@@ -277,6 +302,14 @@ struct SettingsModal: View {
             fetchServerLogos = UserDefaults.standard.object(forKey: "fetchServerLogos") as? Bool ?? true
             windowOpacity = viewModel.settings.windowOpacity
             textVisibilityBoost = viewModel.settings.textVisibilityBoost
+
+            // Load theme from settings
+            if let themeStr = viewModel.settings.overrideTheme,
+               let theme = AppTheme(rawValue: themeStr) {
+                selectedTheme = theme
+            } else {
+                selectedTheme = .auto
+            }
         }
         .alert("Bookmark Storage Failed", isPresented: $showBookmarkAlert) {
             Button("OK", role: .cancel) {}


### PR DESCRIPTION
This update introduces a powerful theme override system that allows users to choose from a variety of beautiful, professionally-designed themes that stay active regardless of which config (Claude Code or Gemini CLI) is active.

Features:
- Override Theme Setting: New setting in AppSettings to store user's theme choice
- 12 New Themes: Nord, Dracula, Solarized (Dark & Light), Monokai Pro, One Dark, GitHub Dark, Tokyo Night, Catppuccin Mocha, Gruvbox Dark, and Material Palenight
- Auto Mode: Default "Auto" option maintains existing behavior (detect from config)
- Real-time Preview: Theme changes apply immediately in Settings modal
- Settings UI: Clean picker interface in Settings modal with helpful description

Theme Highlights:
- Nord: Arctic north-bluish palette with cool tones
- Dracula: Purple/pink accents with dark background
- Solarized: Precision colors in both dark and light variants
- Monokai Pro: Warm dark theme with vibrant yellows and reds
- One Dark: Atom's iconic theme with balanced colors
- GitHub Dark: GitHub's authentic dark theme
- Tokyo Night: Clean dark theme with neon highlights
- Catppuccin Mocha: Warm pastel dark theme
- Gruvbox: Retro groove color scheme
- Material Palenight: Deep ocean syntax theme

Technical Implementation:
- Extended AppTheme enum with all theme cases
- Added ThemeColors presets for each theme with carefully chosen:
  - Background colors (main, sidebar, panel)
  - Text colors (primary, secondary, muted)
  - Accent colors (primary, secondary, success, error, warning)
  - UI element colors (borders, selection, highlights)
  - Beautiful gradients for backgrounds and accents
- Updated ServerViewModel.currentTheme to respect override setting
- Added theme picker in SettingsModal with real-time updates
- All themes professionally color-coordinated for optimal readability

Each theme includes authentic color palettes from their respective design systems, ensuring a professional and polished appearance across all UI elements.