### PR TITLE
Add custom settings for MCP server icons

### DIFF
--- a/MCPServerManager/MCPServerManager/Models/ServerModel.swift
+++ b/MCPServerManager/MCPServerManager/Models/ServerModel.swift
@@ -8,6 +8,7 @@ struct ServerModel: Identifiable, Codable, Equatable {
     var updatedAt: Date
     var inConfigs: [Bool] // [inConfig1, inConfig2]
     var registryImageUrl: String? // Image URL from MCP registry (takes precedence over fetched icons)
+    var customIconPath: String? // User-selected custom icon path (takes highest precedence)
 
     init(id: UUID = UUID(),
          name: String,
@@ -15,7 +16,8 @@ struct ServerModel: Identifiable, Codable, Equatable {
          enabled: Bool = false,
          updatedAt: Date = Date(),
          inConfigs: [Bool] = [false, false],
-         registryImageUrl: String? = nil) {
+         registryImageUrl: String? = nil,
+         customIconPath: String? = nil) {
         self.id = id
         self.name = name
         self.config = config
@@ -23,6 +25,7 @@ struct ServerModel: Identifiable, Codable, Equatable {
         self.updatedAt = updatedAt
         self.inConfigs = inConfigs
         self.registryImageUrl = registryImageUrl
+        self.customIconPath = customIconPath
     }
 
     // MARK: - Computed Properties

--- a/MCPServerManager/MCPServerManager/Services/CustomIconManager.swift
+++ b/MCPServerManager/MCPServerManager/Services/CustomIconManager.swift
@@ -6,9 +6,24 @@ import AppKit
 class CustomIconManager {
     static let shared = CustomIconManager()
 
+    // MARK: - Directory Constants
+
+    private enum Directory {
+        static let appName = "MCPServerManager"
+        static let customIcons = "CustomIcons"
+    }
+
     private init() {
         // Ensure custom icons directory exists
-        try? FileManager.default.createDirectory(at: customIconsDirectory, withIntermediateDirectories: true)
+        do {
+            try FileManager.default.createDirectory(at: customIconsDirectory, withIntermediateDirectories: true)
+        } catch {
+            #if DEBUG
+            print("CustomIconManager: Failed to create icons directory: \(error.localizedDescription)")
+            print("CustomIconManager: Path: \(customIconsDirectory.path)")
+            #endif
+            // Note: Operations will fail gracefully with proper error messages if directory doesn't exist
+        }
     }
 
     // MARK: - Directory Management
@@ -18,8 +33,8 @@ class CustomIconManager {
     private var customIconsDirectory: URL {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
         return appSupport
-            .appendingPathComponent("MCPServerManager", isDirectory: true)
-            .appendingPathComponent("CustomIcons", isDirectory: true)
+            .appendingPathComponent(Directory.appName, isDirectory: true)
+            .appendingPathComponent(Directory.customIcons, isDirectory: true)
     }
 
     // MARK: - Validation Constants
@@ -70,7 +85,14 @@ class CustomIconManager {
         }
 
         // Copy file to custom icons directory
-        try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+        do {
+            try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+        } catch {
+            #if DEBUG
+            print("CustomIconManager: Copy failed - \(error.localizedDescription)")
+            #endif
+            throw CustomIconError.copyFailed
+        }
 
         #if DEBUG
         print("CustomIconManager: Stored icon for server ID '\(serverId.uuidString)' as '\(filename)'")

--- a/MCPServerManager/MCPServerManager/Services/CustomIconManager.swift
+++ b/MCPServerManager/MCPServerManager/Services/CustomIconManager.swift
@@ -1,0 +1,185 @@
+import Foundation
+import AppKit
+
+/// Manages custom icon storage in Application Support directory
+/// Copies user-selected images to a sandboxed location for persistent access
+class CustomIconManager {
+    static let shared = CustomIconManager()
+
+    private init() {
+        // Ensure custom icons directory exists
+        try? FileManager.default.createDirectory(at: customIconsDirectory, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Directory Management
+
+    /// Directory where custom icons are stored
+    /// ~/Library/Application Support/MCPServerManager/CustomIcons/
+    private var customIconsDirectory: URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        return appSupport
+            .appendingPathComponent("MCPServerManager", isDirectory: true)
+            .appendingPathComponent("CustomIcons", isDirectory: true)
+    }
+
+    // MARK: - Validation Constants
+
+    private let maxImageDimension: CGFloat = 2048
+    private let maxFileSizeBytes: Int = 10 * 1024 * 1024 // 10MB
+
+    // MARK: - Public Methods
+
+    /// Validates and copies a user-selected image to the custom icons directory
+    /// - Parameters:
+    ///   - sourceURL: The URL of the user-selected image file
+    ///   - serverName: The name of the server (used to generate unique filename)
+    /// - Returns: The filename of the copied image (not full path)
+    /// - Throws: Error if validation fails or copy fails
+    func storeCustomIcon(from sourceURL: URL, for serverName: String) throws -> String {
+        // Validate file exists
+        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
+            throw CustomIconError.fileNotFound
+        }
+
+        // Validate file size
+        let attributes = try FileManager.default.attributesOfItem(atPath: sourceURL.path)
+        let fileSize = attributes[.size] as? Int ?? 0
+        guard fileSize <= maxFileSizeBytes else {
+            throw CustomIconError.fileTooLarge(sizeInMB: Double(fileSize) / (1024 * 1024))
+        }
+
+        // Validate it's an image and check dimensions
+        guard let image = NSImage(contentsOf: sourceURL) else {
+            throw CustomIconError.invalidImageFormat
+        }
+
+        let size = image.size
+        guard size.width <= maxImageDimension && size.height <= maxImageDimension else {
+            throw CustomIconError.imageTooLarge(width: size.width, height: size.height)
+        }
+
+        // Generate unique filename using server name and original extension
+        let fileExtension = sourceURL.pathExtension
+        let sanitizedName = sanitizeServerName(serverName)
+        let filename = "\(sanitizedName).\(fileExtension)"
+
+        let destinationURL = customIconsDirectory.appendingPathComponent(filename)
+
+        // Remove existing file if present
+        if FileManager.default.fileExists(atPath: destinationURL.path) {
+            try FileManager.default.removeItem(at: destinationURL)
+        }
+
+        // Copy file to custom icons directory
+        try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+
+        #if DEBUG
+        print("CustomIconManager: Stored icon for '\(serverName)' as '\(filename)'")
+        #endif
+
+        return filename
+    }
+
+    /// Loads a custom icon by filename
+    /// - Parameter filename: The filename of the custom icon
+    /// - Returns: NSImage if found and loadable, nil otherwise
+    func loadCustomIcon(filename: String) -> NSImage? {
+        let url = customIconsDirectory.appendingPathComponent(filename)
+
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            #if DEBUG
+            print("CustomIconManager: Icon file not found: \(filename)")
+            #endif
+            return nil
+        }
+
+        return NSImage(contentsOf: url)
+    }
+
+    /// Removes a custom icon file
+    /// - Parameter filename: The filename of the custom icon to remove
+    func removeCustomIcon(filename: String) {
+        let url = customIconsDirectory.appendingPathComponent(filename)
+
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return
+        }
+
+        do {
+            try FileManager.default.removeItem(at: url)
+            #if DEBUG
+            print("CustomIconManager: Removed icon: \(filename)")
+            #endif
+        } catch {
+            #if DEBUG
+            print("CustomIconManager: Failed to remove icon \(filename): \(error)")
+            #endif
+        }
+    }
+
+    /// Removes all unused custom icons (icons not referenced by any server)
+    /// - Parameter usedFilenames: Set of filenames currently in use
+    func cleanupUnusedIcons(usedFilenames: Set<String>) {
+        guard let files = try? FileManager.default.contentsOfDirectory(at: customIconsDirectory, includingPropertiesForKeys: nil) else {
+            return
+        }
+
+        var removedCount = 0
+        for fileURL in files {
+            let filename = fileURL.lastPathComponent
+            if !usedFilenames.contains(filename) {
+                removeCustomIcon(filename: filename)
+                removedCount += 1
+            }
+        }
+
+        #if DEBUG
+        if removedCount > 0 {
+            print("CustomIconManager: Cleaned up \(removedCount) unused icon(s)")
+        }
+        #endif
+    }
+
+    // MARK: - Private Helpers
+
+    /// Sanitizes server name for use as filename
+    private func sanitizeServerName(_ name: String) -> String {
+        // Replace unsafe characters with underscores
+        let unsafe = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_")).inverted
+        let sanitized = name.components(separatedBy: unsafe).joined(separator: "_")
+
+        // Truncate to reasonable length (max 100 chars)
+        let maxLength = 100
+        if sanitized.count > maxLength {
+            let index = sanitized.index(sanitized.startIndex, offsetBy: maxLength)
+            return String(sanitized[..<index])
+        }
+
+        return sanitized
+    }
+}
+
+// MARK: - Custom Icon Errors
+
+enum CustomIconError: LocalizedError {
+    case fileNotFound
+    case fileTooLarge(sizeInMB: Double)
+    case imageTooLarge(width: CGFloat, height: CGFloat)
+    case invalidImageFormat
+    case copyFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .fileNotFound:
+            return "Selected file could not be found"
+        case .fileTooLarge(let sizeMB):
+            return String(format: "Image file is too large (%.1f MB). Maximum size is 10 MB.", sizeMB)
+        case .imageTooLarge(let width, let height):
+            return String(format: "Image dimensions too large (%.0f × %.0f). Maximum is 2048 × 2048 pixels.", width, height)
+        case .invalidImageFormat:
+            return "Selected file is not a valid image format"
+        case .copyFailed:
+            return "Failed to save custom icon"
+        }
+    }
+}

--- a/MCPServerManager/MCPServerManager/Services/CustomIconManager.swift
+++ b/MCPServerManager/MCPServerManager/Services/CustomIconManager.swift
@@ -32,10 +32,10 @@ class CustomIconManager {
     /// Validates and copies a user-selected image to the custom icons directory
     /// - Parameters:
     ///   - sourceURL: The URL of the user-selected image file
-    ///   - serverName: The name of the server (used to generate unique filename)
+    ///   - serverId: The UUID of the server (used to generate unique filename)
     /// - Returns: The filename of the copied image (not full path)
     /// - Throws: Error if validation fails or copy fails
-    func storeCustomIcon(from sourceURL: URL, for serverName: String) throws -> String {
+    func storeCustomIcon(from sourceURL: URL, for serverId: UUID) throws -> String {
         // Validate file exists
         guard FileManager.default.fileExists(atPath: sourceURL.path) else {
             throw CustomIconError.fileNotFound
@@ -58,10 +58,9 @@ class CustomIconManager {
             throw CustomIconError.imageTooLarge(width: size.width, height: size.height)
         }
 
-        // Generate unique filename using server name and original extension
+        // Generate unique filename using server UUID and original extension
         let fileExtension = sourceURL.pathExtension
-        let sanitizedName = sanitizeServerName(serverName)
-        let filename = "\(sanitizedName).\(fileExtension)"
+        let filename = "\(serverId.uuidString).\(fileExtension)"
 
         let destinationURL = customIconsDirectory.appendingPathComponent(filename)
 
@@ -74,7 +73,7 @@ class CustomIconManager {
         try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
 
         #if DEBUG
-        print("CustomIconManager: Stored icon for '\(serverName)' as '\(filename)'")
+        print("CustomIconManager: Stored icon for server ID '\(serverId.uuidString)' as '\(filename)'")
         #endif
 
         return filename
@@ -140,23 +139,6 @@ class CustomIconManager {
         #endif
     }
 
-    // MARK: - Private Helpers
-
-    /// Sanitizes server name for use as filename
-    private func sanitizeServerName(_ name: String) -> String {
-        // Replace unsafe characters with underscores
-        let unsafe = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_")).inverted
-        let sanitized = name.components(separatedBy: unsafe).joined(separator: "_")
-
-        // Truncate to reasonable length (max 100 chars)
-        let maxLength = 100
-        if sanitized.count > maxLength {
-            let index = sanitized.index(sanitized.startIndex, offsetBy: maxLength)
-            return String(sanitized[..<index])
-        }
-
-        return sanitized
-    }
 }
 
 // MARK: - Custom Icon Errors

--- a/MCPServerManager/MCPServerManager/Services/MCPRegistryService.swift
+++ b/MCPServerManager/MCPServerManager/Services/MCPRegistryService.swift
@@ -14,9 +14,9 @@ class MCPRegistryService: ObservableObject {
     private let cacheTimeout: TimeInterval = 3600 // 1 hour
 
     // Compiled regex patterns for better performance (Sendable, safe for concurrent access)
-    private static let jsonBlockRegex = try! NSRegularExpression(pattern: #"```json\s*\n(.*?)\n```"#, options: [.dotMatchesLineSeparators])
-    private static let codeBlockRegex = try! NSRegularExpression(pattern: #"```\s*\n(\{.*?\})\n```"#, options: [.dotMatchesLineSeparators])
-    private static let inlineRegex = try! NSRegularExpression(pattern: #""[^"]+"\s*:\s*\{[\s\S]*?"command"\s*:[\s\S]*?\}"#, options: [])
+    nonisolated(unsafe) private static let jsonBlockRegex = try! NSRegularExpression(pattern: #"```json\s*\n(.*?)\n```"#, options: [.dotMatchesLineSeparators])
+    nonisolated(unsafe) private static let codeBlockRegex = try! NSRegularExpression(pattern: #"```\s*\n(\{.*?\})\n```"#, options: [.dotMatchesLineSeparators])
+    nonisolated(unsafe) private static let inlineRegex = try! NSRegularExpression(pattern: #""[^"]+"\s*:\s*\{[\s\S]*?"command"\s*:[\s\S]*?\}"#, options: [])
 
     private init() {}
 

--- a/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
+++ b/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
@@ -118,6 +118,10 @@ class ServerViewModel: ObservableObject {
                 // Cache to UserDefaults
                 UserDefaults.standard.cachedServers = servers
 
+                // Clean up unused custom icons
+                let usedIcons = Set(servers.compactMap { $0.customIconPath })
+                CustomIconManager.shared.cleanupUnusedIcons(usedFilenames: usedIcons)
+
                 skipSync = false
                 isLoading = false
             } catch {
@@ -126,6 +130,11 @@ class ServerViewModel: ObservableObject {
                 #endif
                 // Load from cache if available
                 servers = UserDefaults.standard.cachedServers
+
+                // Clean up unused custom icons
+                let usedIcons = Set(servers.compactMap { $0.customIconPath })
+                CustomIconManager.shared.cleanupUnusedIcons(usedFilenames: usedIcons)
+
                 skipSync = false
                 isLoading = false
                 showToast(message: "Failed to load config: \(error.localizedDescription)", type: .error)
@@ -583,30 +592,32 @@ class ServerViewModel: ObservableObject {
         showToast(message: "\(server.name) \(status)", type: .success)
     }
 
-    func updateCustomIcon(for server: ServerModel, iconFilename: String?) {
+    func updateCustomIcon(for server: ServerModel, result: Result<String, Error>) {
         guard let index = servers.firstIndex(where: { $0.id == server.id }) else { return }
 
-        // Handle error case (nil means error occurred)
-        guard let filename = iconFilename else {
-            showToast(message: "Failed to set custom icon. Please try again.", type: .error)
-            return
+        switch result {
+        case .success(let filename):
+            // Remove old custom icon if replacing or resetting
+            if let oldFilename = servers[index].customIconPath, oldFilename != filename {
+                CustomIconManager.shared.removeCustomIcon(filename: oldFilename)
+            }
+
+            var updated = servers[index]
+            updated.customIconPath = filename.isEmpty ? nil : filename
+            updated.updatedAt = Date()
+            servers[index] = updated
+
+            // Update cache (no need to sync to config files as custom icons are app-specific)
+            UserDefaults.standard.cachedServers = servers
+
+            let message = filename.isEmpty ? "Icon reset for \(server.name)" : "Custom icon set for \(server.name)"
+            showToast(message: message, type: .success)
+
+        case .failure(let error):
+            // Show specific error message from CustomIconError
+            let errorMessage = error.localizedDescription
+            showToast(message: errorMessage, type: .error)
         }
-
-        // Remove old custom icon if replacing
-        if let oldFilename = servers[index].customIconPath, !oldFilename.isEmpty, filename.isEmpty {
-            CustomIconManager.shared.removeCustomIcon(filename: oldFilename)
-        }
-
-        var updated = servers[index]
-        updated.customIconPath = filename.isEmpty ? nil : filename
-        updated.updatedAt = Date()
-        servers[index] = updated
-
-        // Update cache (no need to sync to config files as custom icons are app-specific)
-        UserDefaults.standard.cachedServers = servers
-
-        let message = filename.isEmpty ? "Icon reset for \(server.name)" : "Custom icon set for \(server.name)"
-        showToast(message: message, type: .success)
     }
 
     func toggleAllServers(_ enable: Bool) {

--- a/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
+++ b/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
@@ -396,18 +396,29 @@ class ServerViewModel: ObservableObject {
         showToast(message: "\(server.name) \(status)", type: .success)
     }
 
-    func updateCustomIcon(for server: ServerModel, iconPath: String) {
+    func updateCustomIcon(for server: ServerModel, iconFilename: String?) {
         guard let index = servers.firstIndex(where: { $0.id == server.id }) else { return }
 
+        // Handle error case (nil means error occurred)
+        guard let filename = iconFilename else {
+            showToast(message: "Failed to set custom icon. Please try again.", type: .error)
+            return
+        }
+
+        // Remove old custom icon if replacing
+        if let oldFilename = servers[index].customIconPath, !oldFilename.isEmpty, filename.isEmpty {
+            CustomIconManager.shared.removeCustomIcon(filename: oldFilename)
+        }
+
         var updated = servers[index]
-        updated.customIconPath = iconPath.isEmpty ? nil : iconPath
+        updated.customIconPath = filename.isEmpty ? nil : filename
         updated.updatedAt = Date()
         servers[index] = updated
 
         // Update cache (no need to sync to config files as custom icons are app-specific)
         UserDefaults.standard.cachedServers = servers
 
-        let message = iconPath.isEmpty ? "Icon reset for \(server.name)" : "Custom icon set for \(server.name)"
+        let message = filename.isEmpty ? "Icon reset for \(server.name)" : "Custom icon set for \(server.name)"
         showToast(message: message, type: .success)
     }
 

--- a/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
+++ b/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
@@ -396,6 +396,21 @@ class ServerViewModel: ObservableObject {
         showToast(message: "\(server.name) \(status)", type: .success)
     }
 
+    func updateCustomIcon(for server: ServerModel, iconPath: String) {
+        guard let index = servers.firstIndex(where: { $0.id == server.id }) else { return }
+
+        var updated = servers[index]
+        updated.customIconPath = iconPath.isEmpty ? nil : iconPath
+        updated.updatedAt = Date()
+        servers[index] = updated
+
+        // Update cache (no need to sync to config files as custom icons are app-specific)
+        UserDefaults.standard.cachedServers = servers
+
+        let message = iconPath.isEmpty ? "Icon reset for \(server.name)" : "Custom icon set for \(server.name)"
+        showToast(message: message, type: .success)
+    }
+
     func toggleAllServers(_ enable: Bool) {
         let configIndex = settings.activeConfigIndex
         #if DEBUG

--- a/MCPServerManager/MCPServerManager/Views/Components/ServerIconView.swift
+++ b/MCPServerManager/MCPServerManager/Views/Components/ServerIconView.swift
@@ -13,6 +13,10 @@ struct ServerIconView: View {
     @State private var showingFilePicker = false
     @Environment(\.themeColors) private var themeColors
 
+    private var isCustomIconSelectable: Bool {
+        onCustomIconSelected != nil
+    }
+
     var body: some View {
         ZStack {
             // Background circle
@@ -62,7 +66,7 @@ struct ServerIconView: View {
             }
 
             // Edit overlay on hover (only show if callback is provided)
-            if isHovering, onCustomIconSelected != nil {
+            if isHovering, isCustomIconSelectable {
                 Circle()
                     .fill(Color.black.opacity(0.6))
 
@@ -74,17 +78,17 @@ struct ServerIconView: View {
         .frame(width: size, height: size)
         .shadow(color: themeColors.primaryAccent.opacity(0.2), radius: 4, x: 0, y: 2)
         .onHover { hovering in
-            if onCustomIconSelected != nil {
+            if isCustomIconSelectable {
                 isHovering = hovering
             }
         }
         .onTapGesture {
-            if onCustomIconSelected != nil {
+            if isCustomIconSelectable {
                 showingFilePicker = true
             }
         }
         .contextMenu {
-            if onCustomIconSelected != nil {
+            if isCustomIconSelectable {
                 Button {
                     showingFilePicker = true
                 } label: {

--- a/MCPServerManager/MCPServerManager/Views/ServerCardView.swift
+++ b/MCPServerManager/MCPServerManager/Views/ServerCardView.swift
@@ -13,6 +13,7 @@ struct ServerCardView: View {
     let onToggle: () -> Void
     let onDelete: () -> Void
     let onUpdate: (String) -> Bool
+    let onCustomIconSelected: ((String) -> Void)?
 
     var body: some View {
         GlassPanel {
@@ -27,7 +28,11 @@ struct ServerCardView: View {
 
                     Spacer()
 
-                    ServerIconView(server: server, size: 40)
+                    ServerIconView(
+                        server: server,
+                        size: 40,
+                        onCustomIconSelected: onCustomIconSelected
+                    )
                 }
 
                 // Config summary

--- a/MCPServerManager/MCPServerManager/Views/ServerCardView.swift
+++ b/MCPServerManager/MCPServerManager/Views/ServerCardView.swift
@@ -19,7 +19,7 @@ struct ServerCardView: View {
     let onDelete: () -> Void
     let onUpdate: (String) -> (success: Bool, invalidReason: String?, config: ServerConfig?)
     let onUpdateForced: (ServerConfig) -> Bool
-    let onCustomIconSelected: ((String?) -> Void)?
+    let onCustomIconSelected: ((Result<String, Error>) -> Void)?
 
     var body: some View {
         GlassPanel {

--- a/MCPServerManager/MCPServerManager/Views/ServerCardView.swift
+++ b/MCPServerManager/MCPServerManager/Views/ServerCardView.swift
@@ -13,7 +13,7 @@ struct ServerCardView: View {
     let onToggle: () -> Void
     let onDelete: () -> Void
     let onUpdate: (String) -> Bool
-    let onCustomIconSelected: ((String) -> Void)?
+    let onCustomIconSelected: ((String?) -> Void)?
 
     var body: some View {
         GlassPanel {

--- a/MCPServerManager/MCPServerManager/Views/ServerGridView.swift
+++ b/MCPServerManager/MCPServerManager/Views/ServerGridView.swift
@@ -27,7 +27,7 @@ struct ServerGridView: View {
                                 return viewModel.updateServer(server, with: json)
                             },
                             onCustomIconSelected: { iconPath in
-                                viewModel.updateCustomIcon(for: server, iconPath: iconPath)
+                                viewModel.updateCustomIcon(for: server, iconFilename: iconPath)
                             }
                         )
                     }

--- a/MCPServerManager/MCPServerManager/Views/ServerGridView.swift
+++ b/MCPServerManager/MCPServerManager/Views/ServerGridView.swift
@@ -25,6 +25,9 @@ struct ServerGridView: View {
                             },
                             onUpdate: { json in
                                 return viewModel.updateServer(server, with: json)
+                            },
+                            onCustomIconSelected: { iconPath in
+                                viewModel.updateCustomIcon(for: server, iconPath: iconPath)
                             }
                         )
                     }

--- a/MCPServerManager/MCPServerManager/Views/ServerGridView.swift
+++ b/MCPServerManager/MCPServerManager/Views/ServerGridView.swift
@@ -30,8 +30,8 @@ struct ServerGridView: View {
                             onUpdateForced: { config in
                                 return viewModel.updateServerForced(server, config: config)
                             },
-                            onCustomIconSelected: { iconPath in
-                                viewModel.updateCustomIcon(for: server, iconFilename: iconPath)
+                            onCustomIconSelected: { result in
+                                viewModel.updateCustomIcon(for: server, result: result)
                             }
                         )
                     }


### PR DESCRIPTION
Users can now click on server icons to set custom images:
- Click icon or right-click for context menu to set custom icon
- Supports all standard image formats (PNG, JPG, etc.)
- Custom icons have highest priority in icon loading hierarchy
- Can reset icons back to default via context menu
- Icon preferences persist in app cache (UserDefaults)

Changes:
- ServerModel: Added customIconPath field to store custom icon paths
- ServerIconView: Made icons clickable with hover effects and file picker
- ServerIconView: Added context menu for setting/resetting icons
- ServerIconView: Updated icon loading to prioritize custom icons
- ServerViewModel: Added updateCustomIcon method to handle icon updates
- ServerCardView: Added onCustomIconSelected callback parameter
- ServerGridView: Connected callback to viewModel.updateCustomIcon

Icon loading priority:
1. Custom user-selected icon (highest priority)
2. Registry image URL
3. IconService fetched icons
4. SF Symbol fallback (lowest priority)