### PR TITLE
Handle MCP server validation and JSON errors

### DIFF
--- a/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
+++ b/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
@@ -222,7 +222,7 @@ class ServerViewModel: ObservableObject {
 
     // MARK: - Server CRUD
 
-    func addServers(from jsonString: String, registryImages: [String: String]? = nil) {
+    func addServers(from jsonString: String, registryImages: [String: String]? = nil) -> (invalidServers: [String: String], serverDict: [String: ServerConfig])? {
         #if DEBUG
         print("DEBUG: Starting addServers with input length: \(jsonString.count)")
         if let images = registryImages {
@@ -236,7 +236,7 @@ class ServerViewModel: ObservableObject {
             print("DEBUG: Failed to parse JSON")
             #endif
             showToast(message: "Could not parse JSON. Please check format.", type: .error)
-            return
+            return nil
         }
 
         guard !serverDict.isEmpty else {
@@ -244,13 +244,46 @@ class ServerViewModel: ObservableObject {
             #if DEBUG
             print("DEBUG: Parsed dictionary is empty")
             #endif
-            return
+            return nil
         }
 
         #if DEBUG
         print("DEBUG: Found \(serverDict.count) servers in JSON")
         #endif
 
+        // Check for invalid servers first
+        var invalidServers: [String: String] = [:]
+        for (name, config) in serverDict {
+            if !config.isValid {
+                let reason = getInvalidReason(config)
+                invalidServers[name] = reason
+            }
+        }
+
+        // If there are invalid servers, return them for UI to handle
+        if !invalidServers.isEmpty {
+            return (invalidServers: invalidServers, serverDict: serverDict)
+        }
+
+        // All servers are valid, proceed with adding
+        addServersInternal(serverDict: serverDict, registryImages: registryImages, skipValidation: false)
+        return nil
+    }
+
+    func addServersForced(from jsonString: String, registryImages: [String: String]? = nil) {
+        #if DEBUG
+        print("DEBUG: Force adding servers, bypassing validation")
+        #endif
+
+        guard let serverDict = ServerExtractor.extractServerEntries(from: jsonString) else {
+            showToast(message: "Could not parse JSON. Please check format.", type: .error)
+            return
+        }
+
+        addServersInternal(serverDict: serverDict, registryImages: registryImages, skipValidation: true)
+    }
+
+    private func addServersInternal(serverDict: [String: ServerConfig], registryImages: [String: String]?, skipValidation: Bool) {
         var addedCount = 0
         var invalidCount = 0
 
@@ -265,7 +298,7 @@ class ServerViewModel: ObservableObject {
             print("DEBUG: Has remotes: \(config.remotes != nil)")
             #endif
 
-            guard config.isValid else {
+            if !skipValidation && !config.isValid {
                 #if DEBUG
                 print("DEBUG: Skipping invalid config for \(name)")
                 #endif
@@ -316,7 +349,9 @@ class ServerViewModel: ObservableObject {
         // Sync to files
         syncToConfigs()
 
-        if invalidCount > 0 {
+        if skipValidation {
+            showToast(message: "Force saved \(addedCount) server(s)", type: .success)
+        } else if invalidCount > 0 {
             showToast(message: "Added \(addedCount) server(s), skipped \(invalidCount) invalid", type: .warning)
         } else {
             showToast(message: "Added \(addedCount) server(s)", type: .success)
@@ -330,7 +365,17 @@ class ServerViewModel: ObservableObject {
         #endif
     }
 
-    func updateServer(_ server: ServerModel, with jsonString: String) -> Bool {
+    private func getInvalidReason(_ config: ServerConfig) -> String {
+        if config.command == nil && config.transport == nil && config.remotes == nil {
+            return "missing command, transport, or remotes"
+        }
+        if let cmd = config.command, cmd.trimmingCharacters(in: .whitespaces).isEmpty {
+            return "empty command"
+        }
+        return "unknown issue"
+    }
+
+    func updateServer(_ server: ServerModel, with jsonString: String) -> (success: Bool, invalidReason: String?) {
         do {
             // Normalize quotes first (curly quotes from Notes/Word/Slack)
             let normalized = jsonString.normalizingQuotes()
@@ -352,10 +397,9 @@ class ServerViewModel: ObservableObject {
                 ])
             }
 
-            guard config.isValid else {
-                throw NSError(domain: "MCPServerManager", code: -1, userInfo: [
-                    NSLocalizedDescriptionKey: "Invalid server config: missing required fields (command, transport, or remotes)"
-                ])
+            if !config.isValid {
+                let reason = getInvalidReason(config)
+                return (success: false, invalidReason: reason)
             }
 
             if let index = servers.firstIndex(where: { $0.id == server.id }) {
@@ -366,6 +410,35 @@ class ServerViewModel: ObservableObject {
 
                 syncToConfigs()
                 showToast(message: "Server updated", type: .success)
+                return (success: true, invalidReason: nil)
+            }
+            return (success: false, invalidReason: nil)
+        } catch {
+            showToast(message: "Failed to update: \(error.localizedDescription)", type: .error)
+            return (success: false, invalidReason: nil)
+        }
+    }
+
+    func updateServerForced(_ server: ServerModel, with jsonString: String) -> Bool {
+        do {
+            let normalized = jsonString.normalizingQuotes()
+
+            guard let data = normalized.data(using: .utf8) else {
+                throw NSError(domain: "MCPServerManager", code: -1, userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to convert JSON string to data"
+                ])
+            }
+
+            let config = try JSONDecoder().decode(ServerConfig.self, from: data)
+
+            if let index = servers.firstIndex(where: { $0.id == server.id }) {
+                var updated = servers[index]
+                updated.config = config
+                updated.updatedAt = Date()
+                servers[index] = updated
+
+                syncToConfigs()
+                showToast(message: "Server force saved", type: .success)
                 return true
             }
             return false
@@ -373,6 +446,91 @@ class ServerViewModel: ObservableObject {
             showToast(message: "Failed to update: \(error.localizedDescription)", type: .error)
             return false
         }
+    }
+
+    func applyRawJSON(_ jsonText: String) -> (success: Bool, invalidServers: [String: String]?) {
+        do {
+            let normalized = jsonText.normalizingQuotes()
+
+            guard let data = normalized.data(using: .utf8) else {
+                throw NSError(domain: "Invalid JSON", code: -1)
+            }
+
+            let serverDict = try JSONDecoder().decode([String: ServerConfig].self, from: data)
+
+            // Check for invalid servers
+            var invalidServers: [String: String] = [:]
+            for (name, config) in serverDict {
+                if !config.isValid {
+                    let reason = getInvalidReason(config)
+                    invalidServers[name] = reason
+                }
+            }
+
+            if !invalidServers.isEmpty {
+                return (success: false, invalidServers: invalidServers)
+            }
+
+            // Apply changes
+            applyRawJSONInternal(serverDict: serverDict, skipValidation: false)
+            return (success: true, invalidServers: nil)
+        } catch {
+            showToast(message: "Failed to parse JSON: \(error.localizedDescription)", type: .error)
+            return (success: false, invalidServers: nil)
+        }
+    }
+
+    func applyRawJSONForced(_ jsonText: String) throws {
+        let normalized = jsonText.normalizingQuotes()
+
+        guard let data = normalized.data(using: .utf8) else {
+            throw NSError(domain: "Invalid JSON", code: -1)
+        }
+
+        let serverDict = try JSONDecoder().decode([String: ServerConfig].self, from: data)
+        applyRawJSONInternal(serverDict: serverDict, skipValidation: true)
+    }
+
+    private func applyRawJSONInternal(serverDict: [String: ServerConfig], skipValidation: Bool) {
+        let configIndex = settings.activeConfigIndex
+
+        // Remove all servers from this config
+        for i in 0..<servers.count {
+            servers[i].inConfigs[configIndex] = false
+        }
+
+        // Add/update servers from JSON
+        for (name, config) in serverDict {
+            if !skipValidation && !config.isValid {
+                continue
+            }
+
+            if let index = servers.firstIndex(where: { $0.name == name }) {
+                var updated = servers[index]
+                updated.config = config
+                updated.inConfigs[configIndex] = true
+                updated.updatedAt = Date()
+                servers[index] = updated
+            } else {
+                var inConfigs = [false, false]
+                inConfigs[configIndex] = true
+
+                let newServer = ServerModel(
+                    name: name,
+                    config: config,
+                    updatedAt: Date(),
+                    inConfigs: inConfigs
+                )
+                servers.append(newServer)
+            }
+        }
+
+        servers.sort { $0.name < $1.name }
+        objectWillChange.send()
+        syncToConfigs()
+
+        let message = skipValidation ? "Configuration force saved" : "Configuration updated"
+        showToast(message: message, type: .success)
     }
 
     func deleteServer(_ server: ServerModel) {

--- a/MCPServerManager/MCPServerManager/Views/RawJSONView.swift
+++ b/MCPServerManager/MCPServerManager/Views/RawJSONView.swift
@@ -6,6 +6,9 @@ struct RawJSONView: View {
     @State private var jsonText: String = ""
     @State private var isDirty: Bool = false
     @State private var errorMessage: String = ""
+    @State private var showForceAlert: Bool = false
+    @State private var invalidServerDetails: String = ""
+    @State private var pendingSaveJSON: String = ""
 
     var body: some View {
         VStack(spacing: 0) {
@@ -151,6 +154,18 @@ struct RawJSONView: View {
                 jsonText = serversToJSON()
             }
         }
+        .alert("Invalid Server Configuration", isPresented: $showForceAlert) {
+            Button("Cancel", role: .cancel) {
+                showForceAlert = false
+                pendingSaveJSON = ""
+                invalidServerDetails = ""
+            }
+            Button("Force Save") {
+                forceSave()
+            }
+        } message: {
+            Text("The following servers have validation errors:\n\n\(invalidServerDetails)\n\nDo you want to force save anyway? This will override all validations.")
+        }
     }
 
     private func serversToJSON() -> String {
@@ -187,53 +202,38 @@ struct RawJSONView: View {
     }
 
     private func applyChanges() {
-        do {
-            // Normalize quotes first (curly quotes from Notes/Word/Slack)
-            let normalized = jsonText.normalizingQuotes()
+        let result = viewModel.applyRawJSON(jsonText)
 
-            guard let data = normalized.data(using: .utf8) else {
-                throw NSError(domain: "Invalid JSON", code: -1)
-            }
-
-            let serverDict = try JSONDecoder().decode([String: ServerConfig].self, from: data)
-            let configIndex = viewModel.settings.activeConfigIndex
-
-            // Remove all servers from this config
-            for i in 0..<viewModel.servers.count {
-                viewModel.servers[i].inConfigs[configIndex] = false
-            }
-
-            // Add/update servers from JSON
-            for (name, config) in serverDict {
-                if let index = viewModel.servers.firstIndex(where: { $0.name == name }) {
-                    var updated = viewModel.servers[index]
-                    updated.config = config
-                    updated.inConfigs[configIndex] = true
-                    updated.updatedAt = Date()
-                    viewModel.servers[index] = updated
-                } else {
-                    var inConfigs = [false, false]
-                    inConfigs[configIndex] = true
-
-                    let newServer = ServerModel(
-                        name: name,
-                        config: config,
-                        updatedAt: Date(),
-                        inConfigs: inConfigs
-                    )
-                    viewModel.servers.append(newServer)
-                }
-            }
-
-            viewModel.servers.sort { $0.name < $1.name }
-            viewModel.objectWillChange.send()
-            viewModel.syncToConfigs()
-
+        if result.success {
+            // Success
             isDirty = false
             errorMessage = ""
-            viewModel.showToast(message: "Configuration updated", type: .success)
+        } else if let invalidServers = result.invalidServers {
+            // Validation failed, show force save alert
+            let details = invalidServers.map { name, reason in
+                "\(name): \(reason)"
+            }.joined(separator: "\n")
+
+            invalidServerDetails = details
+            pendingSaveJSON = jsonText
+            showForceAlert = true
+        } else {
+            // JSON parsing error (toast already shown by viewModel)
+            // Keep isDirty as true and don't clear error
+        }
+    }
+
+    private func forceSave() {
+        do {
+            try viewModel.applyRawJSONForced(pendingSaveJSON)
+            isDirty = false
+            errorMessage = ""
+            showForceAlert = false
+            pendingSaveJSON = ""
+            invalidServerDetails = ""
         } catch {
             errorMessage = "Failed to parse JSON: \(error.localizedDescription)"
+            showForceAlert = false
         }
     }
 }

--- a/MCPServerManager/MCPServerManager/Views/ServerCardView.swift
+++ b/MCPServerManager/MCPServerManager/Views/ServerCardView.swift
@@ -8,11 +8,15 @@ struct ServerCardView: View {
     @State private var editedJSON: String = ""
     @State private var isHovering = false
     @State private var showingDeleteAlert = false
+    @State private var showForceAlert = false
+    @State private var invalidReason: String = ""
+    @State private var pendingSaveJSON: String = ""
     @Environment(\.themeColors) private var themeColors
 
     let onToggle: () -> Void
     let onDelete: () -> Void
-    let onUpdate: (String) -> Bool
+    let onUpdate: (String) -> (success: Bool, invalidReason: String?)
+    let onUpdateForced: (String) -> Bool
 
     var body: some View {
         GlassPanel {
@@ -96,8 +100,14 @@ struct ServerCardView: View {
                             .buttonStyle(.plain)
 
                             Button(action: {
-                                if onUpdate(editedJSON) {
+                                let result = onUpdate(editedJSON)
+                                if result.success {
                                     isEditing = false
+                                } else if let reason = result.invalidReason {
+                                    // Show force save alert
+                                    invalidReason = reason
+                                    pendingSaveJSON = editedJSON
+                                    showForceAlert = true
                                 }
                             }) {
                                 HStack(spacing: 4) {
@@ -188,6 +198,23 @@ struct ServerCardView: View {
                 }
             }
             .padding(DesignTokens.cardPadding)
+        }
+        .alert("Invalid Server Configuration", isPresented: $showForceAlert) {
+            Button("Cancel", role: .cancel) {
+                showForceAlert = false
+                pendingSaveJSON = ""
+                invalidReason = ""
+            }
+            Button("Force Save") {
+                if onUpdateForced(pendingSaveJSON) {
+                    isEditing = false
+                }
+                showForceAlert = false
+                pendingSaveJSON = ""
+                invalidReason = ""
+            }
+        } message: {
+            Text("This server has validation errors:\n\n\(invalidReason)\n\nDo you want to force save anyway? This will override all validations.")
         }
     }
 

--- a/MCPServerManager/MCPServerManager/Views/ServerGridView.swift
+++ b/MCPServerManager/MCPServerManager/Views/ServerGridView.swift
@@ -25,6 +25,9 @@ struct ServerGridView: View {
                             },
                             onUpdate: { json in
                                 return viewModel.updateServer(server, with: json)
+                            },
+                            onUpdateForced: { json in
+                                return viewModel.updateServerForced(server, with: json)
                             }
                         )
                     }


### PR DESCRIPTION
Instead of rejecting invalid MCP server configurations outright, the app now presents users with a force save option when validation fails. This gives users complete control to override validations if they choose.

Changes:
- ServerViewModel: Added force save methods that bypass validation
  - addServersForced(): Skip validation when bulk adding servers
  - updateServerForced(): Skip validation when updating a server
  - applyRawJSONForced(): Skip validation for raw JSON edits
  - Modified existing methods to return validation results instead of silently failing or showing toasts

- AddServerModal: Shows alert dialog when invalid servers are detected
  - Displays specific validation errors for each server
  - Offers "Cancel" or "Force Save" options
  - Clears pending state after user action

- RawJSONView: Shows alert dialog when invalid servers in JSON
  - Uses new applyRawJSON() method for validation checking
  - Displays validation errors with force save option
  - Maintains dirty state correctly

- ServerCardView: Shows alert when editing server with invalid config
  - Updated to handle new updateServer return type
  - Added onUpdateForced closure for force save action
  - Shows specific validation error reason in alert

All alerts follow consistent pattern:
- Clear explanation of validation errors
- Specific details about what's invalid
- Option to cancel or force save
- Warning that force save overrides all validations