### PR TITLE
Add blur toggle for MCP config previews

### DIFF
--- a/MCPServerManager/MCPServerManager/Models/Settings.swift
+++ b/MCPServerManager/MCPServerManager/Models/Settings.swift
@@ -6,6 +6,7 @@ struct AppSettings: Codable, Equatable {
     var activeConfigIndex: Int
     var windowOpacity: Double
     var textVisibilityBoost: Double
+    var blurJSONPreviews: Bool
 
     static let `default` = AppSettings(
         confirmDelete: true,
@@ -15,19 +16,22 @@ struct AppSettings: Codable, Equatable {
         ],
         activeConfigIndex: 0,
         windowOpacity: 1.0,
-        textVisibilityBoost: 0.5
+        textVisibilityBoost: 0.5,
+        blurJSONPreviews: false
     )
 
     init(confirmDelete: Bool = true,
          configPaths: [String] = ["~/.claude.json", "~/.settings.json"],
          activeConfigIndex: Int = 0,
          windowOpacity: Double = 1.0,
-         textVisibilityBoost: Double = 0.5) {
+         textVisibilityBoost: Double = 0.5,
+         blurJSONPreviews: Bool = false) {
         self.confirmDelete = confirmDelete
         self.configPaths = configPaths
         self.activeConfigIndex = max(0, min(activeConfigIndex, 1)) // Ensure 0 or 1
         self.windowOpacity = max(0.3, min(windowOpacity, 1.0)) // Clamp between 0.3 and 1.0
         self.textVisibilityBoost = max(0.0, min(textVisibilityBoost, 1.0)) // Clamp between 0.0 and 1.0
+        self.blurJSONPreviews = blurJSONPreviews
     }
 
     var activeConfigPath: String {

--- a/MCPServerManager/MCPServerManager/Utilities/Constants.swift
+++ b/MCPServerManager/MCPServerManager/Utilities/Constants.swift
@@ -117,6 +117,10 @@ enum DesignTokens {
     static let cardPadding: CGFloat = 16
     static let gridSpacing: CGFloat = 16
 
+    // MARK: - Effects
+
+    static let jsonPreviewBlurRadius: CGFloat = 8
+
     // MARK: - Shadows
 
     static func glassCardShadow() -> some View {

--- a/MCPServerManager/MCPServerManager/Views/Modals/SettingsModal.swift
+++ b/MCPServerManager/MCPServerManager/Views/Modals/SettingsModal.swift
@@ -10,6 +10,7 @@ struct SettingsModal: View {
     @State private var config2Path: String = ""
     @State private var confirmDelete: Bool = true
     @State private var fetchServerLogos: Bool = true
+    @State private var blurJSONPreviews: Bool = false
     @State private var windowOpacity: Double = 1.0
     @State private var textVisibilityBoost: Double = 0.5
     @State private var testingConnection: Bool = false
@@ -133,6 +134,17 @@ struct SettingsModal: View {
                         CheckboxToggle(isOn: $fetchServerLogos, label: "Fetch server logos from internet")
 
                         Text("Automatically download logos for servers. When disabled, only generic icons will be shown. Respects your privacy - no tracking.")
+                            .font(DesignTokens.Typography.bodySmall)
+                            .foregroundColor(.secondary)
+                    }
+
+                    Divider()
+
+                    // Blur JSON Previews
+                    VStack(alignment: .leading, spacing: 8) {
+                        CheckboxToggle(isOn: $blurJSONPreviews, label: "Blur JSON previews")
+
+                        Text("Apply blur effect to JSON code previews in server cards. Blur is temporarily removed when editing.")
                             .font(DesignTokens.Typography.bodySmall)
                             .foregroundColor(.secondary)
                     }
@@ -275,6 +287,7 @@ struct SettingsModal: View {
             config2Path = viewModel.settings.config2Path
             confirmDelete = viewModel.settings.confirmDelete
             fetchServerLogos = UserDefaults.standard.object(forKey: "fetchServerLogos") as? Bool ?? true
+            blurJSONPreviews = viewModel.settings.blurJSONPreviews
             windowOpacity = viewModel.settings.windowOpacity
             textVisibilityBoost = viewModel.settings.textVisibilityBoost
         }
@@ -333,6 +346,7 @@ struct SettingsModal: View {
     private func saveSettings() {
         viewModel.settings.configPaths = [config1Path, config2Path]
         viewModel.settings.confirmDelete = confirmDelete
+        viewModel.settings.blurJSONPreviews = blurJSONPreviews
         viewModel.settings.windowOpacity = windowOpacity
         UserDefaults.standard.set(fetchServerLogos, forKey: "fetchServerLogos")
         viewModel.saveSettings()

--- a/MCPServerManager/MCPServerManager/Views/RawJSONView.swift
+++ b/MCPServerManager/MCPServerManager/Views/RawJSONView.swift
@@ -66,6 +66,7 @@ struct RawJSONView: View {
                 .background(Color.black.opacity(0.3))
                 .padding(20)
                 .focusable(true)
+                .blur(radius: (viewModel.settings.blurJSONPreviews && !isDirty) ? 8 : 0)
                 .onChange(of: jsonText) { newValue in
                     isDirty = newValue != serversToJSON()
                 }

--- a/MCPServerManager/MCPServerManager/Views/RawJSONView.swift
+++ b/MCPServerManager/MCPServerManager/Views/RawJSONView.swift
@@ -66,7 +66,7 @@ struct RawJSONView: View {
                 .background(Color.black.opacity(0.3))
                 .padding(20)
                 .focusable(true)
-                .blur(radius: (viewModel.settings.blurJSONPreviews && !isDirty) ? 8 : 0)
+                .blur(radius: (viewModel.settings.blurJSONPreviews && !isDirty) ? DesignTokens.jsonPreviewBlurRadius : 0)
                 .onChange(of: jsonText) { newValue in
                     isDirty = newValue != serversToJSON()
                 }

--- a/MCPServerManager/MCPServerManager/Views/ServerCardView.swift
+++ b/MCPServerManager/MCPServerManager/Views/ServerCardView.swift
@@ -129,7 +129,7 @@ struct ServerCardView: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(8)
                                 .secondaryTextVisibility()
-                                .blur(radius: blurJSONPreviews ? 8 : 0)
+                                .blur(radius: (blurJSONPreviews && !isEditing) ? DesignTokens.jsonPreviewBlurRadius : 0)
                         }
                         .frame(height: 200)
                         .background(Color.black.opacity(0.3))

--- a/MCPServerManager/MCPServerManager/Views/ServerCardView.swift
+++ b/MCPServerManager/MCPServerManager/Views/ServerCardView.swift
@@ -4,6 +4,7 @@ struct ServerCardView: View {
     let server: ServerModel
     @Binding var activeConfigIndex: Int
     @Binding var confirmDelete: Bool
+    @Binding var blurJSONPreviews: Bool
     @State private var isEditing = false
     @State private var editedJSON: String = ""
     @State private var isHovering = false
@@ -128,6 +129,7 @@ struct ServerCardView: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(8)
                                 .secondaryTextVisibility()
+                                .blur(radius: blurJSONPreviews ? 8 : 0)
                         }
                         .frame(height: 200)
                         .background(Color.black.opacity(0.3))

--- a/MCPServerManager/MCPServerManager/Views/ServerGridView.swift
+++ b/MCPServerManager/MCPServerManager/Views/ServerGridView.swift
@@ -17,6 +17,7 @@ struct ServerGridView: View {
                             server: server,
                             activeConfigIndex: $viewModel.settings.activeConfigIndex,
                             confirmDelete: $viewModel.settings.confirmDelete,
+                            blurJSONPreviews: $viewModel.settings.blurJSONPreviews,
                             onToggle: {
                                 viewModel.toggleServer(server)
                             },


### PR DESCRIPTION
- Add blurJSONPreviews setting to AppSettings (default: false)
- Add checkbox toggle in Settings modal to control blur effect
- Apply 8pt blur to JSON previews in ServerCardView when enabled
- Blur automatically removes when user clicks edit button
- Apply blur to RawJSONView that removes when editing starts
- Blur restores when user cancels or saves edits

This feature helps reduce visual clutter while maintaining full accessibility - the blur effect intelligently disables during active editing sessions.