### PR TITLE
Add window menu to reopen main window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Nothing yet
 
 ### Fixed
+- **Window Menu Compliance** - Added Window menu with "Show Main Window" option to meet App Store requirements. Users can now reopen the main window after closing it via Window → Show Main Window (⌘0)
 - **Custom Icon Picker** - Fixed non-functional icon click by replacing SwiftUI fileImporter with native NSOpenPanel
 - **Registry API Update** - Updated to correct GitHub MCP registry endpoint (api.mcp.github.com/v0/servers)
 - **Sparkle Update Feed** - Corrected SUFeedURL to point to proper GitHub repository

--- a/MCPServerManager/MCPServerManager/MCPServerManagerApp.swift
+++ b/MCPServerManager/MCPServerManager/MCPServerManagerApp.swift
@@ -22,6 +22,18 @@ struct MCPServerManagerApp: App {
         .commands {
             CommandGroup(replacing: .newItem) {}
 
+            // Window menu for reopening closed windows (required by App Store)
+            CommandGroup(after: .windowList) {
+                Button("Show Main Window") {
+                    // Reopen the main window if it was closed
+                    if let window = NSApp.windows.first {
+                        window.makeKeyAndOrderFront(nil)
+                        NSApp.activate(ignoringOtherApps: true)
+                    }
+                }
+                .keyboardShortcut("0", modifiers: [.command])
+            }
+
             // Only show "Check for Updates" for non-App Store builds
             if updateChecker.canCheckForUpdates {
                 CommandGroup(after: .appInfo) {


### PR DESCRIPTION
Fixed App Store rejection (Guideline 4 - Design) by adding a Window menu that allows users to reopen the main window after closing it.

Changes:
- Added "Show Main Window" menu item in Window menu (⌘0 shortcut)
- Implements proper window management for macOS App Store requirements
- Users can now reopen closed windows without restarting the app

Resolves App Store review issue: "no menu item to re-open main window"