### PR TITLE
Add syntax highlighting and live validation to Add Servers modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - **SwiftLint Linting** - Added a tuned `.swiftlint.yml` (complexity, file/function/line length, naming, and TODO tracking rules), a `Lint` GitHub Actions workflow that runs `swiftlint lint --strict` on every push/PR, and a pre-commit hook that lints staged changes. The existing source was brought to **zero** violations (safe renames of single-letter locals, tuple→struct refactors, long-line wrapping, and splitting oversized types/files), with no behavior change.
 - **Live Config Watching** - The app now watches your config file and reloads automatically when it changes on disk (edited by another tool, CLI, or editor). Debounced and resilient to atomic saves; no more stale views.
-- **JSON Syntax Highlighting** - Server config previews, the inline card editor, and the Raw JSON editor now render theme-aware, syntax-highlighted JSON (keys, strings, numbers, booleans/null, and punctuation), with caching for smooth scrolling.
+- **JSON Syntax Highlighting** - Server config previews, the inline card editor, the Raw JSON editor, and the Add Servers editor now render theme-aware, syntax-highlighted JSON (keys, strings, numbers, booleans/null, and punctuation), with caching for smooth scrolling.
 - **Inline Rename** - Edit a server's top-level JSON key in the card editor to rename it; collisions and empty names are rejected with a clear message.
 - **Transport Badge** - Each server card shows a transport badge (stdio / HTTP / SSE) at a glance, plus a context menu (Edit, Copy JSON, Delete) and improved accessibility labels.
 - **`servers` Wrapper Support** - Pasting configs wrapped in `"servers"` (the VS Code / GitHub Copilot format) now works just like `"mcpServers"`; the wrapper is unwrapped automatically.
 - **Paste a URL to Add** - Pasting a bare URL (e.g. `https://mcp.magicpatterns.com/mcp`) and clicking Add now creates an HTTP server keyed by the domain (e.g. `magicpatterns`). A missing scheme defaults to `https://`.
 
 ### Changed
+- **Live Validation in Add Servers** - The Add Servers modal now validates the manual JSON as you type and shows inline valid/invalid feedback, so the separate **Validate** button has been removed. The editor is also syntax-highlighted, matching the Raw JSON editor.
 - **Single Config Model** - Simplified to a single active configuration. A server is either enabled (present in the config) or not, replacing the previous dual-config enabled-state arrays.
 - **⌘R Reloads From Disk** - The refresh button and ⌘R now reload servers from the config file instead of re-writing it.
 - **Real "Recent" Filter** - The Recent filter now shows servers modified within the last 24 hours, most-recent first.
@@ -26,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Internal Cleanup** - Simplified source across models, services, view models, and views (deduplicated JSON encoding, flattened redundant conditionals and availability guards) with no behavior change.
 
 ### Fixed
+- **Valid Config Message Now Green** - In the Add Servers modal, the "Valid! Found N server(s)" confirmation now renders in the theme's success green. Previously it always used red error styling regardless of whether the configuration was actually valid.
 - **"Open App" Always Opens the Window** - Hardened the menu bar "Open App" action (and the Dock icon / ⌘0) so it reliably brings the main window to the front, even after the window has been closed. The window is now tracked directly instead of being guessed from `NSApp.windows` (which could match a hidden helper window and leave nothing visible on screen), is reopened through the window scene when it no longer exists, is activated with the macOS 14+ cooperative activation API where available, and is re-checked on the next run loop as a fallback. Resolves an App Store review finding (Guideline 2.1(a)) where clicking "Open App" appeared to do nothing.
 - **Consistent Custom Fonts Across Build Paths** - Poppins / Crimson Pro now register reliably whether the app is built via the GitHub Actions workflow (xcodebuild) or locally for Transporter (`swift build`). `FontManager` now discovers fonts by recursively scanning the bundle instead of probing fixed paths, the Info.plist uses the correct macOS `ATSApplicationFontsPath` key (the old iOS-only `UIAppFonts` key was ignored), and both build paths embed fonts in `Contents/Resources/Fonts`. Previously some App Store builds silently fell back to the system font.
 

--- a/MCPServerManager/MCPServerManager/Views/Modals/AddServerModal.swift
+++ b/MCPServerManager/MCPServerManager/Views/Modals/AddServerModal.swift
@@ -4,11 +4,12 @@ struct AddServerModal: View {
     @Binding var isPresented: Bool
     @ObservedObject var viewModel: ServerViewModel
     @Environment(\.themeColors) private var themeColors
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
     // MARK: - Entry State
 
     @State private var jsonText = ""
-    @State private var errorMessage = ""
+    @State private var validationStatus: ValidationStatus = .none
     @State private var entryMode: EntryMode = .manual
     @State private var registryImages: [String: String] = [:]
 
@@ -23,6 +24,13 @@ struct AddServerModal: View {
     private enum EntryMode {
         case manual
         case browse
+    }
+
+    /// Live validation result for the manual JSON entry field.
+    private enum ValidationStatus: Equatable {
+        case none
+        case valid(Int)
+        case invalid(String)
     }
 
     var body: some View {
@@ -122,7 +130,6 @@ struct AddServerModal: View {
     private var footerView: some View {
         HStack(spacing: 12) {
             SecondaryButton(icon: "text.alignleft", title: "Format JSON", action: formatJSON)
-            SecondaryButton(icon: "checkmark.shield", title: "Validate", action: validateJSON)
 
             Spacer()
 
@@ -152,37 +159,59 @@ struct AddServerModal: View {
                     .font(DesignTokens.Typography.bodySmall)
                     .foregroundColor(.secondary)
 
-                TextEditor(text: $jsonText)
-                    .font(DesignTokens.Typography.codeLarge)
-                    .frame(minHeight: 350, idealHeight: 450, maxHeight: 600)
-                    .scrollContentBackground(.hidden)
-                    .background(Color.black.opacity(0.3))
-                    .cornerRadius(12)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color.white.opacity(0.1), lineWidth: 1)
-                    )
-                    .focusable(true)
-
-                if !errorMessage.isEmpty {
-                    errorMessageView
+                JSONCodeEditor(
+                    text: $jsonText,
+                    themeColors: themeColors,
+                    fontSize: 15,
+                    reduceTransparency: reduceTransparency
+                )
+                .frame(minHeight: 350, idealHeight: 450, maxHeight: 600)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.white.opacity(0.1), lineWidth: 1)
+                )
+                .onChange(of: jsonText) { _ in
+                    validateInput()
                 }
+
+                validationStatusView
             }
             .padding(24)
         }
     }
 
-    private var errorMessageView: some View {
+    @ViewBuilder
+    private var validationStatusView: some View {
+        switch validationStatus {
+        case .none:
+            EmptyView()
+        case .valid(let count):
+            statusBanner(
+                icon: "checkmark.circle.fill",
+                message: "Valid! Found \(count) server\(count == 1 ? "" : "s")",
+                color: themeColors.successColor
+            )
+        case .invalid(let message):
+            statusBanner(
+                icon: "exclamationmark.triangle.fill",
+                message: message,
+                color: themeColors.errorColor
+            )
+        }
+    }
+
+    private func statusBanner(icon: String, message: String, color: Color) -> some View {
         HStack {
-            Image(systemName: "exclamationmark.triangle.fill")
-            Text(errorMessage)
+            Image(systemName: icon)
+            Text(message)
         }
         .font(DesignTokens.Typography.bodySmall)
-        .foregroundColor(.red)
+        .foregroundColor(color)
         .padding(12)
         .background(
             RoundedRectangle(cornerRadius: 8)
-                .fill(Color.red.opacity(0.1))
+                .fill(color.opacity(0.1))
         )
     }
 
@@ -198,7 +227,7 @@ struct AddServerModal: View {
 
     private func resetForm() {
         jsonText = ""
-        errorMessage = ""
+        validationStatus = .none
         registryImages = [:]
         clearPendingState()
     }
@@ -207,22 +236,29 @@ struct AddServerModal: View {
 
     private func formatJSON() {
         guard let result = JSONFormatter.prettyPrinted(jsonText) else {
-            errorMessage = "Invalid JSON format (after normalizing quotes)"
+            validationStatus = .invalid("Invalid JSON format (after normalizing quotes)")
             return
         }
+        // Assigning `jsonText` triggers `onChange`, which re-runs `validateInput()`.
         jsonText = result
-        errorMessage = ""
     }
 
-    private func validateJSON() {
+    /// Validate the manual JSON entry. Runs live as the user edits and drives
+    /// `validationStatusView` (green when valid, red when invalid).
+    private func validateInput() {
+        guard !jsonText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            validationStatus = .none
+            return
+        }
+
         guard let serverDict = ServerExtractor.extractServerEntries(from: jsonText) else {
-            errorMessage = "Could not parse JSON. Expected format: "
-                + "{\"server-name\": {\"command\": \"...\"}} or wrap in {\"mcpServers\": {...}}"
+            validationStatus = .invalid("Could not parse JSON. Expected format: "
+                + "{\"server-name\": {\"command\": \"...\"}} or wrap in {\"mcpServers\": {...}}")
             return
         }
 
         guard !serverDict.isEmpty else {
-            errorMessage = "No valid server configurations found in JSON"
+            validationStatus = .invalid("No valid server configurations found in JSON")
             return
         }
 
@@ -231,11 +267,11 @@ struct AddServerModal: View {
             let details = invalidServers
                 .map { "\($0.key): \(getInvalidReason($0.value))" }
                 .joined(separator: "; ")
-            errorMessage = "Invalid server config(s): \(details)"
+            validationStatus = .invalid("Invalid server config(s): \(details)")
             return
         }
 
-        errorMessage = "Valid! Found \(serverDict.count) server(s)"
+        validationStatus = .valid(serverDict.count)
     }
 
     private func getInvalidReason(_ config: ServerConfig) -> String {
@@ -274,7 +310,7 @@ struct AddServerModal: View {
             pendingRegistryImages = images
             showForceAlert = true
         case .failed:
-            errorMessage = "Could not add servers. Review the JSON and try again."
+            validationStatus = .invalid("Could not add servers. Review the JSON and try again.")
         }
     }
 
@@ -302,7 +338,7 @@ struct AddServerModal: View {
         withAnimation(.easeInOut(duration: 0.2)) {
             entryMode = .manual
         }
-        errorMessage = ""
+        validateInput()
     }
 
     private func encodeAsPrettyJSON(_ value: [String: ServerConfig]) -> String? {


### PR DESCRIPTION
## Summary
- Bring the **Add Servers** modal's manual JSON entry in line with the rest of the app by replacing the plain `TextEditor` with the shared, theme-aware `JSONCodeEditor` — the same syntax highlighter used by the Raw JSON editor and the inline card editor.
- Remove the **Validate** button and validate **live as the user edits** (via `onChange`), replacing the single `errorMessage` string with a `ValidationStatus` model (`none` / `valid` / `invalid`).
- Fix the validity message color: a valid config now renders in the theme **success green** with a checkmark, instead of always showing red error styling regardless of validity.

## Changes
- `Views/Modals/AddServerModal.swift` — editor swap, live `onChange` validation, green/red status banner; removed the Validate button and routed `formatJSON` / `addServers` failures into the new invalid state.
- `CHANGELOG.md` — `[Unreleased]` Added/Changed/Fixed entries.

## Notes
- Validation reuses the existing `ServerExtractor` + `ServerConfig.isValid` logic, so *what* counts as valid is unchanged — only *how* and *when* it's surfaced.
- This change could not be compiled or linted in the build environment (macOS-only SwiftUI/AppKit app; the sandbox is Linux). Please rely on CI (`swiftlint lint --strict`) and a local `swift build`.

## Test plan
- [ ] Open **Add Servers → Manual Entry**: the JSON editor is syntax-highlighted and theme-aware (matches the Raw JSON editor).
- [ ] Type invalid JSON → an inline **red** banner with a warning icon describes the problem.
- [ ] Type/paste a valid config → an inline **green** banner with a checkmark reads "Valid! Found N server(s)".
- [ ] Confirm the **Validate** button is gone; **Format JSON** still works.
- [ ] Select a server from **Browse Registry** → the editor populates and immediately shows the green valid state.
- [ ] `swiftlint lint --strict` passes and `swift build` succeeds locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
