### PR TITLE
Add Factory Droid and JetBrains Junie CI workflows

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -1,0 +1,31 @@
+name: Droid Auto Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  droid-review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Droid Auto Review
+        uses: Factory-AI/droid-action@main
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          automatic_review: true
+          review_model: gpt-5.2

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -2,7 +2,7 @@ name: Droid Auto Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   droid-review:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'droid-review')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@main
+        uses: Factory-AI/droid-action@v5
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@main
+        uses: Factory-AI/droid-action@dev
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@v5
+        uses: Factory-AI/droid-action@main
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -1,0 +1,38 @@
+name: Droid Tag
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  droid:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@droid')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@droid') || contains(github.event.issue.title, '@droid'))) ||
+      (github.event_name == 'pull_request' && (contains(github.event.pull_request.body, '@droid') || contains(github.event.pull_request.title, '@droid')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Droid Exec
+        uses: Factory-AI/droid-action@main
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -33,6 +33,6 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@v5
+        uses: Factory-AI/droid-action@main
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -33,6 +33,6 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@main
+        uses: Factory-AI/droid-action@v5
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -33,6 +33,6 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@main
+        uses: Factory-AI/droid-action@dev
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}

--- a/.github/workflows/junie-review.yml
+++ b/.github/workflows/junie-review.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: JetBrains/junie-github-action@v1.3.9
+      - uses: JetBrains/junie-github-action@v1.4.8
         with:
           junie_api_key: ${{ secrets.JUNIE_API_KEY }}
           use_single_comment: "true"

--- a/.github/workflows/junie-review.yml
+++ b/.github/workflows/junie-review.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: JetBrains/junie-github-action@v1.4.8
+      - uses: JetBrains/junie-github-action@main
         with:
           junie_api_key: ${{ secrets.JUNIE_API_KEY }}
           use_single_comment: "true"

--- a/.github/workflows/junie-review.yml
+++ b/.github/workflows/junie-review.yml
@@ -1,0 +1,27 @@
+name: Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+    branches: [main]
+
+jobs:
+  review:
+    if: contains(github.event.pull_request.labels.*.name, 'junie-review')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: JetBrains/junie-github-action@v1.3.9
+        with:
+          junie_api_key: ${{ secrets.JUNIE_API_KEY }}
+          use_single_comment: "true"
+          prompt: "code-review"
+          junie_version: "latest"
+          model: "gpt-5.2-2025-12-11"

--- a/.github/workflows/junie-tag.yml
+++ b/.github/workflows/junie-tag.yml
@@ -1,0 +1,42 @@
+name: Junie Ask
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned, labeled]
+  pull_request:
+    types: [opened, assigned, labeled]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  junie:
+    if: |
+      (github.event_name == 'issue_comment' && (contains(github.event.comment.body, '@junie-agent') || contains(github.event.comment.body, '@junie'))) ||
+      (github.event_name == 'pull_request_review_comment' && (contains(github.event.comment.body, '@junie-agent') || contains(github.event.comment.body, '@junie'))) ||
+      (github.event_name == 'pull_request_review' && (contains(github.event.review.body, '@junie-agent') || contains(github.event.review.body, '@junie'))) ||
+      (github.event_name == 'issues' && (github.event.issue.assignee.login == 'junie-agent' || contains(github.event.issue.labels.*.name, 'junie') || contains(github.event.issue.body, '@junie-agent') || contains(github.event.issue.body, '@junie') || contains(github.event.issue.title, '@junie-agent') || contains(github.event.issue.title, '@junie'))) ||
+      (github.event_name == 'pull_request' && (github.event.pull_request.assignee.login == 'junie-agent' || contains(github.event.pull_request.labels.*.name, 'junie') || contains(github.event.pull_request.body, '@junie-agent') || contains(github.event.pull_request.body, '@junie') || contains(github.event.pull_request.title, '@junie-agent') || contains(github.event.pull_request.title, '@junie')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Junie
+        id: junie
+        uses: JetBrains/junie-github-action@v1.3.9
+        with:
+          junie_api_key: ${{ secrets.JUNIE_API_KEY }}
+          assignee_trigger: "junie-agent"
+          use_single_comment: true
+          junie_version: "latest"
+          model: "gemini-3-flash-preview"

--- a/.github/workflows/junie-tag.yml
+++ b/.github/workflows/junie-tag.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Junie
         id: junie
-        uses: JetBrains/junie-github-action@v1.3.9
+        uses: JetBrains/junie-github-action@v1.4.8
         with:
           junie_api_key: ${{ secrets.JUNIE_API_KEY }}
           assignee_trigger: "junie-agent"

--- a/.github/workflows/junie-tag.yml
+++ b/.github/workflows/junie-tag.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Junie
         id: junie
-        uses: JetBrains/junie-github-action@v1.4.8
+        uses: JetBrains/junie-github-action@main
         with:
           junie_api_key: ${{ secrets.JUNIE_API_KEY }}
           assignee_trigger: "junie-agent"


### PR DESCRIPTION
Ports the Factory Droid and JetBrains Junie GitHub Actions workflows from the droidproxy repo into mcp-panel.

## Workflows added
- **droid-review.yml** — Factory Droid automatic PR review on opened/ready_for_review/reopened (model `gpt-5.2`).
- **droid.yml** — Factory Droid `@droid` tag handler for issue/PR/review comments, issues, and PRs.
- **junie-review.yml** — JetBrains Junie code review on PRs labeled `junie-review` (model `gpt-5.2-2025-12-11`).
- **junie-tag.yml** — JetBrains Junie `@junie`/`@junie-agent` tag and assignee handler (model `gemini-3-flash-preview`).

## Secrets
`FACTORY_API_KEY` and `JUNIE_API_KEY` repository secrets have been configured via the gh CLI.

## Test plan
- Merge and open a test PR to confirm Droid auto-review and Junie review (with the `junie-review` label) trigger.
- Comment `@droid` and `@junie` on a PR/issue to confirm the tag handlers run.

Co-authored-by: Claude <noreply@anthropic.com>