### PR TITLE
Add drag-and-drop JSON to add a server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- **Drag-and-Drop to Add Servers** - Drop JSON text or a `.json` file anywhere on the window to open the Add Servers modal pre-filled with that content, ready to review and add. A highlighted drop overlay appears while dragging. Non-`.json` files are ignored, and invalid JSON still surfaces the normal validation messaging. The existing paste and file-import paths are unchanged.
 - **SwiftLint Linting** - Added a tuned `.swiftlint.yml` (complexity, file/function/line length, naming, and TODO tracking rules), a `Lint` GitHub Actions workflow that runs `swiftlint lint --strict` on every push/PR, and a pre-commit hook that lints staged changes. The existing source was brought to **zero** violations (safe renames of single-letter locals, tuple→struct refactors, long-line wrapping, and splitting oversized types/files), with no behavior change.
 - **Live Config Watching** - The app now watches your config file and reloads automatically when it changes on disk (edited by another tool, CLI, or editor). Debounced and resilient to atomic saves; no more stale views.
 - **JSON Syntax Highlighting** - Server config previews, the inline card editor, the Raw JSON editor, and the Add Servers editor now render theme-aware, syntax-highlighted JSON (keys, strings, numbers, booleans/null, and punctuation), with caching for smooth scrolling.

--- a/MCPServerManager/MCPServerManager/Views/ContentView.swift
+++ b/MCPServerManager/MCPServerManager/Views/ContentView.swift
@@ -248,17 +248,16 @@ struct ContentView: View {
     /// Routes through the Add Server modal (pre-filled) so the user can review,
     /// rather than the silent import path.
     private func handleDrop(providers: [NSItemProvider]) -> Bool {
-        // Prefer a dropped file URL; fall back to plain text.
+        // Prefer a dropped .json file; fall back to plain text. Using
+        // `loadFileRepresentation` copies the file into a sandbox-readable temp
+        // location (a plain file URL fails under the App Store sandbox), and
+        // matching `UTType.json` means we only accept (and animate) real JSON.
         if let fileProvider = providers.first(where: {
-            $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
+            $0.hasItemConformingToTypeIdentifier(UTType.json.identifier)
         }) {
-            _ = fileProvider.loadObject(ofClass: URL.self) { url, _ in
-                guard let url, url.pathExtension.lowercased() == "json" else { return }
-                let accessing = url.startAccessingSecurityScopedResource()
-                defer {
-                    if accessing { url.stopAccessingSecurityScopedResource() }
-                }
-                guard let data = try? Data(contentsOf: url),
+            _ = fileProvider.loadFileRepresentation(forTypeIdentifier: UTType.json.identifier) { url, _ in
+                guard let url,
+                      let data = try? Data(contentsOf: url),
                       let jsonString = String(data: data, encoding: .utf8) else { return }
                 DispatchQueue.main.async {
                     presentAddServer(with: jsonString)

--- a/MCPServerManager/MCPServerManager/Views/ContentView.swift
+++ b/MCPServerManager/MCPServerManager/Views/ContentView.swift
@@ -12,6 +12,8 @@ struct ContentView: View {
     @State private var showImportForceAlert = false
     @State private var importInvalidServerDetails = ""
     @State private var pendingImportServers: [String: ServerConfig]?
+    @State private var droppedJSON: String?
+    @State private var isDropTargeted = false
 
     var body: some View {
         ZStack {
@@ -25,12 +27,21 @@ struct ContentView: View {
                 SettingsModal(isPresented: $showSettings, viewModel: viewModel)
             }
             modalOverlay(isPresented: showAddServer) {
-                AddServerModal(isPresented: $showAddServer, viewModel: viewModel)
+                AddServerModal(isPresented: $showAddServer, viewModel: viewModel, initialJSON: droppedJSON)
             }
+            dropTargetOverlay
         }
         .environment(\.themeColors, viewModel.themeColors)
         .environment(\.currentTheme, viewModel.currentTheme)
         .frame(minWidth: 900, minHeight: 600)
+        .onDrop(of: [.fileURL, .text], isTargeted: $isDropTargeted) { providers in
+            handleDrop(providers: providers)
+        }
+        .onChange(of: showAddServer) { isShowing in
+            if !isShowing {
+                droppedJSON = nil
+            }
+        }
         .fileImporter(
             isPresented: $showImporter,
             allowedContentTypes: [.json],
@@ -182,6 +193,40 @@ struct ContentView: View {
     }
 
     @ViewBuilder
+    private var dropTargetOverlay: some View {
+        if isDropTargeted {
+            ZStack {
+                viewModel.themeColors.primaryAccent.opacity(0.12)
+                    .ignoresSafeArea()
+
+                VStack(spacing: 16) {
+                    Image(systemName: "arrow.down.doc.fill")
+                        .font(.system(size: 48))
+                        .foregroundColor(viewModel.themeColors.primaryAccent)
+                    Text("Drop JSON to add servers")
+                        .font(DesignTokens.Typography.bodyLarge)
+                }
+                .padding(40)
+                .background(
+                    RoundedRectangle(cornerRadius: 20)
+                        .fill(Color(nsColor: .windowBackgroundColor))
+                        .shadow(radius: 30)
+                )
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 0)
+                    .strokeBorder(
+                        viewModel.themeColors.primaryAccent,
+                        style: StrokeStyle(lineWidth: 3, dash: [12, 8])
+                    )
+                    .ignoresSafeArea()
+            )
+            .transition(.opacity)
+            .allowsHitTesting(false)
+        }
+    }
+
+    @ViewBuilder
     private func modalOverlay<Content: View>(
         isPresented: Bool,
         @ViewBuilder content: () -> Content
@@ -195,6 +240,54 @@ struct ContentView: View {
             }
             .transition(.opacity)
         }
+    }
+
+    // MARK: - Drop Handler
+
+    /// Handle JSON dropped onto the window: a `.json` file or plain text.
+    /// Routes through the Add Server modal (pre-filled) so the user can review,
+    /// rather than the silent import path.
+    private func handleDrop(providers: [NSItemProvider]) -> Bool {
+        // Prefer a dropped file URL; fall back to plain text.
+        if let fileProvider = providers.first(where: {
+            $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
+        }) {
+            _ = fileProvider.loadObject(ofClass: URL.self) { url, _ in
+                guard let url, url.pathExtension.lowercased() == "json" else { return }
+                let accessing = url.startAccessingSecurityScopedResource()
+                defer {
+                    if accessing { url.stopAccessingSecurityScopedResource() }
+                }
+                guard let data = try? Data(contentsOf: url),
+                      let jsonString = String(data: data, encoding: .utf8) else { return }
+                DispatchQueue.main.async {
+                    presentAddServer(with: jsonString)
+                }
+            }
+            return true
+        }
+
+        if let textProvider = providers.first(where: {
+            $0.canLoadObject(ofClass: NSString.self)
+        }) {
+            _ = textProvider.loadObject(ofClass: NSString.self) { text, _ in
+                guard let text = text as? String else { return }
+                let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return }
+                DispatchQueue.main.async {
+                    presentAddServer(with: trimmed)
+                }
+            }
+            return true
+        }
+
+        return false
+    }
+
+    /// Pre-fill the Add Server modal with the given text and present it.
+    private func presentAddServer(with json: String) {
+        droppedJSON = json
+        showAddServer = true
     }
 
     // MARK: - Import Handler

--- a/MCPServerManager/MCPServerManager/Views/Modals/AddServerModal.swift
+++ b/MCPServerManager/MCPServerManager/Views/Modals/AddServerModal.swift
@@ -8,10 +8,16 @@ struct AddServerModal: View {
 
     // MARK: - Entry State
 
-    @State private var jsonText = ""
+    @State private var jsonText: String
     @State private var validationStatus: ValidationStatus = .none
     @State private var entryMode: EntryMode = .manual
     @State private var registryImages: [String: String] = [:]
+
+    init(isPresented: Binding<Bool>, viewModel: ServerViewModel, initialJSON: String? = nil) {
+        self._isPresented = isPresented
+        self._viewModel = ObservedObject(wrappedValue: viewModel)
+        self._jsonText = State(initialValue: initialJSON ?? "")
+    }
 
     // MARK: - Force Save State
 
@@ -42,6 +48,11 @@ struct AddServerModal: View {
             contentView
             Divider()
             footerView
+        }
+        .onAppear {
+            if !jsonText.isEmpty {
+                validateInput()
+            }
         }
         .frame(
             minWidth: 700,

--- a/MCPServerManager/MCPServerManager/Views/Modals/AddServerModal.swift
+++ b/MCPServerManager/MCPServerManager/Views/Modals/AddServerModal.swift
@@ -6,9 +6,13 @@ struct AddServerModal: View {
     @Environment(\.themeColors) private var themeColors
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
+    /// JSON to pre-fill the editor with (e.g. from a drag-and-drop), seeded on
+    /// appear and whenever it changes while the modal is open.
+    let initialJSON: String?
+
     // MARK: - Entry State
 
-    @State private var jsonText: String
+    @State private var jsonText = ""
     @State private var validationStatus: ValidationStatus = .none
     @State private var entryMode: EntryMode = .manual
     @State private var registryImages: [String: String] = [:]
@@ -16,7 +20,7 @@ struct AddServerModal: View {
     init(isPresented: Binding<Bool>, viewModel: ServerViewModel, initialJSON: String? = nil) {
         self._isPresented = isPresented
         self._viewModel = ObservedObject(wrappedValue: viewModel)
-        self._jsonText = State(initialValue: initialJSON ?? "")
+        self.initialJSON = initialJSON
     }
 
     // MARK: - Force Save State
@@ -50,7 +54,14 @@ struct AddServerModal: View {
             footerView
         }
         .onAppear {
-            if !jsonText.isEmpty {
+            if let initialJSON, !initialJSON.isEmpty {
+                jsonText = initialJSON
+                validateInput()
+            }
+        }
+        .onChange(of: initialJSON) { newValue in
+            if let newValue, !newValue.isEmpty {
+                jsonText = newValue
                 validateInput()
             }
         }


### PR DESCRIPTION
Closes #41

## What changed
Drag JSON content onto the main window to add servers:

- **Drop JSON text** → opens the **Add Servers** modal pre-filled with the dropped text in its `jsonText` editor.
- **Drop a `.json` file** → reads the file and opens the Add Servers modal pre-filled with its contents (routed through the review flow, not the silent import path).
- A highlighted, dashed **drop overlay** ("Drop JSON to add servers") appears while a drag is over the window.
- Non-`.json` files are ignored; invalid JSON still surfaces the existing live validation messaging in the modal.
- Existing paste and ⌘-import file paths are unchanged.

## Implementation
- `ContentView`: added `.onDrop(of: [.fileURL, .text])` with `handleDrop(providers:)`. It prefers a dropped `.json` file URL (with security-scoped access for the sandbox), falling back to plain text, then pre-fills and presents the modal. A `dropTargetOverlay` provides visual feedback; `droppedJSON` is cleared when the modal closes.
- `AddServerModal`: added an `initialJSON` init parameter that seeds the `jsonText` `@State`, and validates on appear so the dropped content immediately shows valid/invalid status. Reuses the existing `ServerExtractor` / force-save / validation flow — no bypass.

## Acceptance criteria
- [x] Dropping JSON text onto the window opens Add Servers pre-filled with that text.
- [x] Dropping a `.json` file opens Add Servers pre-filled with the file contents.
- [x] Existing paste and file-import paths still work.
- [x] Invalid JSON still surfaces the normal validation messaging.

## Test plan
- `swift build` — clean.
- `swiftlint lint --strict` — **0 violations** across 46 files.
- Built the signed dev `.app` and launched it in an **isolated `HOME`** (temp dir + seeded `~/.claude.json`) so the real config was never touched (confirmed: real `~/.claude.json` mtime unchanged).
- Verified the exact `handleDrop` extraction logic against real `NSItemProvider`s (the same objects SwiftUI delivers to `.onDrop`):
  - Text drop → extracted `{"playwright": {"command": "npx", "args": ["@playwright/mcp@latest"]}}`
  - `.json` file drop → extracted the file's contents
  - `.txt` file drop → correctly ignored (no modal)
