### PR TITLE
Add sort options for the server list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- **Sort Options for the Server List** - A new sort control in the toolbar lets you order servers by **Name (A→Z)** (default), **Enabled First** (enabled servers grouped above disabled), or **Recently Modified** (newest first). Sorting is applied as a view concern (it no longer mutates the stored order) and respects the active filter and search. Your choice persists across launches.
 - **SwiftLint Linting** - Added a tuned `.swiftlint.yml` (complexity, file/function/line length, naming, and TODO tracking rules), a `Lint` GitHub Actions workflow that runs `swiftlint lint --strict` on every push/PR, and a pre-commit hook that lints staged changes. The existing source was brought to **zero** violations (safe renames of single-letter locals, tuple→struct refactors, long-line wrapping, and splitting oversized types/files), with no behavior change.
 - **Live Config Watching** - The app now watches your config file and reloads automatically when it changes on disk (edited by another tool, CLI, or editor). Debounced and resilient to atomic saves; no more stale views.
 - **JSON Syntax Highlighting** - Server config previews, the inline card editor, the Raw JSON editor, and the Add Servers editor now render theme-aware, syntax-highlighted JSON (keys, strings, numbers, booleans/null, and punctuation), with caching for smooth scrolling.

--- a/MCPServerManager/MCPServerManager/Models/Settings.swift
+++ b/MCPServerManager/MCPServerManager/Models/Settings.swift
@@ -148,6 +148,36 @@ enum FilterMode: String, Codable, CaseIterable {
     }
 }
 
+enum SortMode: String, Codable, CaseIterable {
+    case name
+    case enabledFirst
+    case recentlyModified
+
+    var displayName: String {
+        switch self {
+        case .name: return "Name (A→Z)"
+        case .enabledFirst: return "Enabled First"
+        case .recentlyModified: return "Recently Modified"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .name: return "Name"
+        case .enabledFirst: return "Enabled"
+        case .recentlyModified: return "Recent"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .name: return "textformat.abc"
+        case .enabledFirst: return "checkmark.circle"
+        case .recentlyModified: return "clock"
+        }
+    }
+}
+
 // MARK: - Array Extension for Safe Access
 
 extension Array {

--- a/MCPServerManager/MCPServerManager/Services/ConfigManager.swift
+++ b/MCPServerManager/MCPServerManager/Services/ConfigManager.swift
@@ -216,6 +216,7 @@ extension UserDefaults {
         static let settings = "app_settings"
         static let servers = "cached_servers"
         static let hasCompletedOnboarding = "has_completed_onboarding"
+        static let sortMode = "server_sort_mode"
     }
 
     private func decode<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {
@@ -240,5 +241,10 @@ extension UserDefaults {
     var hasCompletedOnboarding: Bool {
         get { bool(forKey: Keys.hasCompletedOnboarding) }
         set { set(newValue, forKey: Keys.hasCompletedOnboarding) }
+    }
+
+    var sortMode: SortMode {
+        get { SortMode(rawValue: string(forKey: Keys.sortMode) ?? "") ?? .name }
+        set { set(newValue.rawValue, forKey: Keys.sortMode) }
     }
 }

--- a/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel+Filtering.swift
+++ b/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel+Filtering.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+// MARK: - Filtering, Searching & Sorting
+
+extension ServerViewModel {
+    var filteredServers: [ServerModel] {
+        var filtered = servers
+
+        // Apply filter mode
+        switch filterMode {
+        case .all:
+            break
+        case .active:
+            filtered = filtered.filter { $0.enabled }
+        case .disabled:
+            filtered = filtered.filter { !$0.enabled }
+        case .recent:
+            // Servers modified within the last 24 hours.
+            let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
+            filtered = filtered.filter { $0.updatedAt >= cutoff }
+        }
+
+        // Apply search
+        if !searchText.isEmpty {
+            filtered = filtered.filter { server in
+                server.name.localizedCaseInsensitiveContains(searchText) ||
+                server.config.summary.localizedCaseInsensitiveContains(searchText) ||
+                server.configJSON.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+
+        return sorted(filtered)
+    }
+
+    /// Apply the active sort order. Ties fall back to a stable A→Z by name.
+    private func sorted(_ servers: [ServerModel]) -> [ServerModel] {
+        switch sortMode {
+        case .name:
+            return servers.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        case .enabledFirst:
+            return servers.sorted { lhs, rhs in
+                if lhs.enabled != rhs.enabled { return lhs.enabled }
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+        case .recentlyModified:
+            return servers.sorted { lhs, rhs in
+                if lhs.updatedAt != rhs.updatedAt { return lhs.updatedAt > rhs.updatedAt }
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+        }
+    }
+}

--- a/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel+Filtering.swift
+++ b/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel+Filtering.swift
@@ -33,6 +33,8 @@ extension ServerViewModel {
     }
 
     /// Apply the active sort order. Ties fall back to a stable A→Z by name.
+    /// This is a view concern only: it returns a new array and never mutates the
+    /// stored `servers`, so the on-disk/synced order stays stable.
     private func sorted(_ servers: [ServerModel]) -> [ServerModel] {
         switch sortMode {
         case .name:

--- a/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
+++ b/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
@@ -22,6 +22,12 @@ class ServerViewModel: ObservableObject {
     @Published var searchText: String = ""
     @Published var viewMode: ViewMode = .grid
     @Published var filterMode: FilterMode = .all
+    @Published var sortMode: SortMode = .name {
+        didSet {
+            guard sortMode != oldValue else { return }
+            UserDefaults.standard.sortMode = sortMode
+        }
+    }
     @Published var isLoading: Bool = false
     @Published var showOnboarding: Bool = false
     @Published var selectedServer: ServerModel?
@@ -68,6 +74,7 @@ class ServerViewModel: ObservableObject {
 
     init() {
         loadSettings()
+        sortMode = UserDefaults.standard.sortMode
 
         // Show onboarding if first time
         showOnboarding = !UserDefaults.standard.hasCompletedOnboarding
@@ -82,39 +89,6 @@ class ServerViewModel: ObservableObject {
     deinit {
         fileWatcher?.stop()
         healthCheckTasks.values.forEach { $0.cancel() }
-    }
-
-    // MARK: - Filtering & Searching
-
-    var filteredServers: [ServerModel] {
-        var filtered = servers
-
-        // Apply filter mode
-        switch filterMode {
-        case .all:
-            break
-        case .active:
-            filtered = filtered.filter { $0.enabled }
-        case .disabled:
-            filtered = filtered.filter { !$0.enabled }
-        case .recent:
-            // Servers modified within the last 24 hours, ordered most-recent first.
-            let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
-            filtered = filtered
-                .filter { $0.updatedAt >= cutoff }
-                .sorted { $0.updatedAt > $1.updatedAt }
-        }
-
-        // Apply search
-        if !searchText.isEmpty {
-            filtered = filtered.filter { server in
-                server.name.localizedCaseInsensitiveContains(searchText) ||
-                server.config.summary.localizedCaseInsensitiveContains(searchText) ||
-                server.configJSON.localizedCaseInsensitiveContains(searchText)
-            }
-        }
-
-        return filtered
     }
 
     // MARK: - Settings Management

--- a/MCPServerManager/MCPServerManager/Views/Components/ToolbarView.swift
+++ b/MCPServerManager/MCPServerManager/Views/Components/ToolbarView.swift
@@ -193,10 +193,51 @@ struct ToolbarView: View {
     @ViewBuilder
     private func rightSideActions() -> some View {
         HStack(spacing: 10) {
+            sortMenu()
             enableByTagMenu()
             toggleAllButton()
             refreshButton()
         }
+    }
+
+    @ViewBuilder
+    private func sortMenu() -> some View {
+        Menu {
+            ForEach(SortMode.allCases, id: \.self) { mode in
+                Button {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.75)) {
+                        viewModel.sortMode = mode
+                    }
+                } label: {
+                    Label {
+                        Text(mode.displayName)
+                    } icon: {
+                        if viewModel.sortMode == mode {
+                            Image(systemName: "checkmark")
+                        } else {
+                            Image(systemName: mode.icon)
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.up.arrow.down")
+                    .font(.system(size: 13, weight: .medium))
+                Text(viewModel.sortMode.label)
+                    .font(DesignTokens.Typography.labelSmall)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .bold))
+                    .opacity(0.6)
+            }
+            .fixedSize(horizontal: true, vertical: false)
+            .modifier(ToolbarButtonStyle())
+        }
+        .buttonStyle(.plain)
+        .help("Sort servers")
+        .accessibilityLabel("Sort servers")
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Closes #43.

Adds a user-selectable sort order to the toolbar (next to the Tags menu / All-On toggle) with three modes:

- **Name (A→Z)** — current default
- **Enabled First** — enabled servers grouped above disabled (each group A→Z)
- **Recently Modified** — by `updatedAt`, newest first

## Implementation

- New `SortMode` enum in `Settings.swift` (alongside `ViewMode` / `FilterMode`), with `displayName`, short `label`, and SF Symbol `icon`.
- `@Published var sortMode` on `ServerViewModel`, loaded on init and persisted to a dedicated `UserDefaults` key (`server_sort_mode`) via a `didSet`.
- Sorting is applied as a **view concern** inside `filteredServers` (after filter + search), never mutating the stored `servers` array — so the on-disk/stored order stays stable. All sorts fall back to a stable A→Z by name on ties.
- `filteredServers` and the sort helper were moved into a new `ServerViewModel+Filtering.swift` extension to keep `ServerViewModel` within the SwiftLint file/type-length limits.
- A `sortMenu()` control added to `ToolbarView` rightSideActions, mirroring the existing `Menu` styling (`ToolbarButtonStyle`), showing a checkmark on the active mode.

## Acceptance criteria

- [x] User can switch between Name, Enabled-first, and Recently-modified sorting.
- [x] Sorting is applied in `filteredServers` and respects the active filter/search.
- [x] Default remains Name (A→Z); selection persists across launches.

## Test plan

Built a signed local bundle and smoke-tested against an **isolated** defaults domain + temp config (never touched real `~/.claude.json` or the app's real UserDefaults), seeded with 5 servers (zebra, mango enabled; apple, carrot, delta disabled) with distinct `updatedAt` values:

- **Name** → apple, carrot, delta, mango, zebra ✅
- **Enabled First** → mango, zebra (enabled), then apple, carrot, delta (disabled) ✅
- **Recently Modified** → delta, zebra, mango, apple, carrot (newest→oldest) ✅
- Each mode was loaded from persisted defaults on a fresh launch, confirming persistence ✅
- Filter pill counts (All 5 / Active 2 / Disabled 3) and search remain correct under each sort ✅

Local validation:
- `swift build` — clean
- `swiftlint lint --strict` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
