### PR TITLE
Add sort options for the server list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Inline Rename** - Edit a server's top-level JSON key in the card editor to rename it; collisions and empty names are rejected with a clear message.
 - **Transport Badge** - Each server card shows a transport badge (stdio / HTTP / SSE) at a glance, plus a context menu (Edit, Copy JSON, Delete) and improved accessibility labels.
 - **Server Health Checks** - Each server card now has a Check action that performs a lightweight health check: HTTP/SSE configs ping their endpoint with a short timeout, and stdio configs verify that the command resolves on PATH. Results appear inline on the card and in a toast.
+- **Sort Options** - A new sort control in the toolbar lets you order the server list by Name (A→Z, the default), Enabled first, or Recently modified. Sorting is applied alongside the active filter/search and your choice persists across launches.
 - **`servers` Wrapper Support** - Pasting configs wrapped in `"servers"` (the VS Code / GitHub Copilot format) now works just like `"mcpServers"`; the wrapper is unwrapped automatically.
 - **Paste a URL to Add** - Pasting a bare URL (e.g. `https://mcp.magicpatterns.com/mcp`) and clicking Add now creates an HTTP server keyed by the domain (e.g. `magicpatterns`). A missing scheme defaults to `https://`.
 
@@ -20,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **Live Validation in Add Servers** - The Add Servers modal now validates the manual JSON as you type and shows inline valid/invalid feedback, so the separate **Validate** button has been removed. The editor is also syntax-highlighted, matching the Raw JSON editor.
 - **Single Config Model** - Simplified to a single active configuration. A server is either enabled (present in the config) or not, replacing the previous dual-config enabled-state arrays.
 - **⌘R Reloads From Disk** - The refresh button and ⌘R now reload servers from the config file instead of re-writing it.
-- **Real "Recent" Filter** - The Recent filter now shows servers modified within the last 24 hours, most-recent first.
+- **Real "Recent" Filter** - The Recent filter now shows servers modified within the last 24 hours; use the new "Recently modified" sort to order them most-recent first.
 - **Renamed to "MCP Panel"** - User-facing app name updated throughout the UI.
 - **Normal Dock App** - The app now shows in the Dock like a standard macOS app (activation policy `.regular`) while keeping the menu bar icon, instead of running as an accessory/menu-bar-only app.
 - **Simplified Theme Setting** - Removed the "Auto (Detect from Config)" theme option; the app now defaults to the Claude Code theme, and you can pick any of the built-in themes directly.

--- a/MCPServerManager/MCPServerManager/Models/Settings.swift
+++ b/MCPServerManager/MCPServerManager/Models/Settings.swift
@@ -148,6 +148,43 @@ enum FilterMode: String, Codable, CaseIterable {
     }
 }
 
+enum SortMode: String, Codable, CaseIterable {
+    case name
+    case enabledFirst
+    case recent
+
+    var displayName: String {
+        switch self {
+        case .name: return "Name (A→Z)"
+        case .enabledFirst: return "Enabled First"
+        case .recent: return "Recently Modified"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .name: return "Name"
+        case .enabledFirst: return "Enabled"
+        case .recent: return "Recent"
+        }
+    }
+
+    /// Orders servers for display according to this sort mode.
+    func sorted(_ list: [ServerModel]) -> [ServerModel] {
+        switch self {
+        case .name:
+            return list.sorted { $0.name < $1.name }
+        case .enabledFirst:
+            return list.sorted {
+                if $0.enabled != $1.enabled { return $0.enabled }
+                return $0.name < $1.name
+            }
+        case .recent:
+            return list.sorted { $0.updatedAt > $1.updatedAt }
+        }
+    }
+}
+
 // MARK: - Array Extension for Safe Access
 
 extension Array {

--- a/MCPServerManager/MCPServerManager/Models/Settings.swift
+++ b/MCPServerManager/MCPServerManager/Models/Settings.swift
@@ -180,7 +180,10 @@ enum SortMode: String, Codable, CaseIterable {
                 return $0.name < $1.name
             }
         case .recent:
-            return list.sorted { $0.updatedAt > $1.updatedAt }
+            return list.sorted {
+                if $0.updatedAt != $1.updatedAt { return $0.updatedAt > $1.updatedAt }
+                return $0.name < $1.name
+            }
         }
     }
 }

--- a/MCPServerManager/MCPServerManager/Services/ConfigManager.swift
+++ b/MCPServerManager/MCPServerManager/Services/ConfigManager.swift
@@ -216,6 +216,7 @@ extension UserDefaults {
         static let settings = "app_settings"
         static let servers = "cached_servers"
         static let hasCompletedOnboarding = "has_completed_onboarding"
+        static let sortMode = "server_sort_mode"
     }
 
     private func decode<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {
@@ -240,5 +241,10 @@ extension UserDefaults {
     var hasCompletedOnboarding: Bool {
         get { bool(forKey: Keys.hasCompletedOnboarding) }
         set { set(newValue, forKey: Keys.hasCompletedOnboarding) }
+    }
+
+    var sortMode: SortMode {
+        get { string(forKey: Keys.sortMode).flatMap(SortMode.init) ?? .name }
+        set { set(newValue.rawValue, forKey: Keys.sortMode) }
     }
 }

--- a/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
+++ b/MCPServerManager/MCPServerManager/ViewModels/ServerViewModel.swift
@@ -22,6 +22,7 @@ class ServerViewModel: ObservableObject {
     @Published var searchText: String = ""
     @Published var viewMode: ViewMode = .grid
     @Published var filterMode: FilterMode = .all
+    @Published var sortMode: SortMode = .name { didSet { UserDefaults.standard.sortMode = sortMode } }
     @Published var isLoading: Bool = false
     @Published var showOnboarding: Bool = false
     @Published var selectedServer: ServerModel?
@@ -68,6 +69,7 @@ class ServerViewModel: ObservableObject {
 
     init() {
         loadSettings()
+        sortMode = UserDefaults.standard.sortMode
 
         // Show onboarding if first time
         showOnboarding = !UserDefaults.standard.hasCompletedOnboarding
@@ -98,11 +100,9 @@ class ServerViewModel: ObservableObject {
         case .disabled:
             filtered = filtered.filter { !$0.enabled }
         case .recent:
-            // Servers modified within the last 24 hours, ordered most-recent first.
+            // Servers modified within the last 24 hours.
             let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
-            filtered = filtered
-                .filter { $0.updatedAt >= cutoff }
-                .sorted { $0.updatedAt > $1.updatedAt }
+            filtered = filtered.filter { $0.updatedAt >= cutoff }
         }
 
         // Apply search
@@ -114,7 +114,8 @@ class ServerViewModel: ObservableObject {
             }
         }
 
-        return filtered
+        // Sorting is a view-only concern; the stored `servers` order stays stable.
+        return sortMode.sorted(filtered)
     }
 
     // MARK: - Settings Management

--- a/MCPServerManager/MCPServerManager/Views/Components/ToolbarView.swift
+++ b/MCPServerManager/MCPServerManager/Views/Components/ToolbarView.swift
@@ -193,10 +193,49 @@ struct ToolbarView: View {
     @ViewBuilder
     private func rightSideActions() -> some View {
         HStack(spacing: 10) {
+            sortMenu()
             enableByTagMenu()
             toggleAllButton()
             refreshButton()
         }
+    }
+
+    @ViewBuilder
+    private func sortMenu() -> some View {
+        Menu {
+            ForEach(SortMode.allCases, id: \.self) { mode in
+                Button {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.75)) {
+                        viewModel.sortMode = mode
+                    }
+                } label: {
+                    Label {
+                        Text(mode.displayName)
+                    } icon: {
+                        if viewModel.sortMode == mode {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.up.arrow.down")
+                    .font(.system(size: 13, weight: .medium))
+                Text(viewModel.sortMode.label)
+                    .font(DesignTokens.Typography.labelSmall)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .bold))
+                    .opacity(0.6)
+            }
+            .fixedSize(horizontal: true, vertical: false)
+            .modifier(ToolbarButtonStyle())
+        }
+        .buttonStyle(.plain)
+        .help("Sort servers")
+        .accessibilityLabel("Sort servers")
     }
 
     @ViewBuilder


### PR DESCRIPTION
Closes #43

## What
Adds a user-selectable **sort order** for the server list, surfaced as a menu in the toolbar (next to the Tags menu / All-On toggle). The list was previously locked to alphabetical-by-name.

Options:
- **Name (A→Z)** — current default.
- **Enabled First** — enabled servers grouped above disabled (name A→Z within each group).
- **Recently Modified** — by `updatedAt`, most-recent first.

## How
- New `SortMode` enum in `Settings.swift` (alongside `ViewMode` / `FilterMode`), with a `sorted(_:)` method that owns the ordering logic.
- `@Published var sortMode` on `ServerViewModel`; sorting is applied in the `filteredServers` computed property via `sortMode.sorted(filtered)`, **not** by mutating `servers` in place — so the stored order stays stable and sort is purely a view concern. It composes with the active filter and search.
- The `.recent` **filter** no longer self-sorts (that ordering now lives in the `.recent` **sort**); it still scopes to the last 24h.
- Selection persists across launches in `UserDefaults` (`server_sort_mode`), read in `init` and written via `didSet`.
- Toolbar control is a `Menu` mirroring the existing `enableByTagMenu()` styling, with a checkmark on the active option and an `arrow.up.arrow.down` icon.

## Acceptance criteria
- [x] User can switch between Name, Enabled-first, and Recently-modified sorting.
- [x] Sorting is applied in `filteredServers` and respects the active filter/search.
- [x] Default remains Name (A→Z); selection persists across launches.

## Validation
- `swift build` — clean.
- `swiftlint lint --strict` — **0 violations**.
- **Logic verified deterministically** by compiling the real `SortMode.sorted` against a mixed mock set (enabled/disabled, varied names + `updatedAt`):
  ```
  PASS name          -> [apple, banana, cherry*, mango*, zebra*]
  PASS enabledFirst  -> [cherry*, mango*, zebra*, apple, banana]
  PASS recent        -> [apple, cherry*, mango*, zebra*, banana]
  PASS inputUnmutated (sort never mutates the stored servers array)
  ```
  (`*` = enabled)
- **Smoke-tested the real app**: launched the built binary, opened the new toolbar sort menu, and confirmed all three options render with a checkmark on the active selection. (Screenshots omitted from the repo to keep the tree clean and avoid leaking config contents.)